### PR TITLE
database: add json serialize function for configuration

### DIFF
--- a/betree/src/database/errors.rs
+++ b/betree/src/database/errors.rs
@@ -15,5 +15,6 @@ error_chain! {
         InUse
         InDestruction
         MessageTooLarge
+        SerializeFailed
     }
 }


### PR DESCRIPTION
This may be useful in situations (such as the benchmarks) where we specify the desired configuration externally. They currently require the `json` format, though `yaml` or perhaps `toml` would provide a better editability