### PR TITLE
Add CI for `betree`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci-pr
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  betree:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Debug
+      run: |
+        echo $PWD
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+    - name: Dependency Cache
+      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+    - name: Build
+      run: |
+        cd betree/tests
+        cargo build
+    - name: Run tests
+      run: |
+        cd betree/tests
+        ./scripts/ci-test.sh
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    tags:
-      - v*
+    branches: [main]
 
 jobs:
   betree:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Dependency Cache
+      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
     - name: Run integration tests
       run: |
         cd betree/tests
@@ -49,6 +51,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Dependency Cache
+      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
     - name: Run internal tests
       run: |
         cd betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- -y
+        source $HOME/.cargo/env
+        rustup toolchain install --profile minimal --force stable
     - name: Dependency Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
   betree-integration:
     needs: [betree-build]
     runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -49,6 +51,8 @@ jobs:
   betree-internal:
     needs: [betree-build]
     runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: ci-pr
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    tags:
+      - v*
 
 jobs:
   betree:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
+        target-dir: "../.target"
     - name: Build
       run: |
         cd betree
@@ -40,6 +41,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
+        target-dir: "../.target"
     - name: Run integration tests
       run: |
         cd betree/tests
@@ -56,6 +58,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
+        target-dir: "../.target"
     - name: Run internal tests
       run: |
         cd betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
         profile: minimal
         override: true
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: "betree"
     - name: Build
       run: |
         cd betree
@@ -35,7 +37,9 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: "betree"
     - name: Run integration tests
       run: |
         cd betree/tests
@@ -49,7 +53,9 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      uses: Swatinem/rust-cache@v1
+      with:
+        sharedKey: "betree"
     - name: Run internal tests
       run: |
         cd betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Debug
-      run: |
-        echo $PWD
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
-        target-dir: "../.target"
+        target-dir: "../target"
     - name: Build
       run: |
         cd betree
@@ -41,7 +41,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
-        target-dir: "../.target"
+        target-dir: "../target"
     - name: Run integration tests
       run: |
         cd betree/tests
@@ -58,7 +58,7 @@ jobs:
       uses: Swatinem/rust-cache@v1
       with:
         sharedKey: "betree"
-        target-dir: "../.target"
+        target-dir: "../target"
     - name: Run internal tests
       run: |
         cd betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,17 @@ jobs:
         profile: minimal
         override: true
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@v1
+      uses: actions/cache@v3
       with:
-        sharedKey: "betree"
-        target-dir: "../target"
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
+          ../target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Build
       run: |
         cd betree
@@ -40,10 +47,17 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@v1
+      uses: actions/cache@v3
       with:
-        sharedKey: "betree"
-        target-dir: "../target"
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
+          ../target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Run integration tests
       run: |
         cd betree/tests
@@ -59,10 +73,17 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Dependency Cache
-      uses: Swatinem/rust-cache@v1
+      uses: actions/cache@v3
       with:
-        sharedKey: "betree"
-        target-dir: "../target"
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
+          ../target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Run internal tests
       run: |
         cd betree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           ~/.cargo/git
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
-          ../target/
+          ./target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Build
       run: |
@@ -55,7 +55,7 @@ jobs:
           ~/.cargo/git
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
-          ../target/
+          ./target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Run integration tests
       run: |
@@ -81,7 +81,7 @@ jobs:
           ~/.cargo/git
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
-          ../target/
+          ./target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }} }}
     - name: Run internal tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  betree:
+  betree-build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -27,10 +27,30 @@ jobs:
       uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
     - name: Build
       run: |
-        cd betree/tests
+        cd betree
         cargo build
-    - name: Run tests
+  betree-integration:
+    needs: [betree-build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Run integration tests
       run: |
         cd betree/tests
+        ./scripts/ci-test.sh
+  betree-internal:
+    needs: [betree-build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Run internal tests
+      run: |
+        cd betree
         ./scripts/ci-test.sh
 

--- a/betree/scripts/ci-test.sh
+++ b/betree/scripts/ci-test.sh
@@ -12,4 +12,9 @@ for tst in "${failed[@]}"
 do
     printf '%b' "$(echo "$tst" | sed -e 's/\"//g')"
 done
-exit "$(echo "$failed" | wc -l)"
+if [ -z "$failed" ]
+then
+        exit 0
+else
+        exit 1
+fi

--- a/betree/scripts/ci-test.sh
+++ b/betree/scripts/ci-test.sh
@@ -1,5 +1,15 @@
-#!/bin/env bash
+#! /bin/env bash
 
 # num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
-failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | tee /dev/stderr | grep suite | grep failed | jq '.failed')
-exit $failed
+failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json \
+    | grep name \
+    | grep failed \
+    | jq '"Test: " + .name + "\n-----LOG-----\n" + .stdout + "---END LOG---\n" ' \
+      )
+echo "FAILED TESTS"
+echo "############"
+for tst in "${failed[@]}"
+do
+    printf '%b' "$(echo "$tst" | sed -e 's/\"//g')"
+done
+exit "$(echo "$failed" | wc -l)"

--- a/betree/scripts/ci-test.sh
+++ b/betree/scripts/ci-test.sh
@@ -1,7 +1,7 @@
 #! /bin/env bash
 
 # num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
-failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json \
+failed=$(cargo test -- -Z unstable-options --format json \
     | grep name \
     | grep failed \
     | jq '"Test: " + .name + "\n-----LOG-----\n" + .stdout + "---END LOG---\n" ' \

--- a/betree/scripts/ci-test.sh
+++ b/betree/scripts/ci-test.sh
@@ -1,0 +1,5 @@
+#!/bin/env bash
+
+# num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
+failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | tee /dev/stderr | grep suite | grep failed | jq '.failed')
+exit $failed

--- a/betree/tests/scripts/ci-test.sh
+++ b/betree/tests/scripts/ci-test.sh
@@ -12,4 +12,9 @@ for tst in "${failed[@]}"
 do
     printf '%b' "$(echo "$tst" | sed -e 's/\"//g')"
 done
-exit "$(echo "$failed" | wc -l)"
+if [ -z "$failed" ]
+then
+        exit 0
+else
+        exit 1
+fi

--- a/betree/tests/scripts/ci-test.sh
+++ b/betree/tests/scripts/ci-test.sh
@@ -1,5 +1,15 @@
 #! /bin/env bash
 
 # num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
-failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | tee /dev/stderr | grep suite | grep failed | jq '.failed')
-exit $failed
+failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json \
+    | grep name \
+    | grep failed \
+    | jq '"Test: " + .name + "\n-----LOG-----\n" + .stdout + "---END LOG---\n" ' \
+      )
+echo "FAILED TESTS"
+echo "############"
+for tst in "${failed[@]}"
+do
+    printf '%b' "$(echo "$tst" | sed -e 's/\"//g')"
+done
+exit "$(echo "$failed" | wc -l)"

--- a/betree/tests/scripts/ci-test.sh
+++ b/betree/tests/scripts/ci-test.sh
@@ -1,5 +1,5 @@
 #! /bin/env bash
 
 # num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
-failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | grep suite | grep failed | jq '.failed')
+failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | tee /dev/stderr | grep suite | grep failed | jq '.failed')
 exit $failed

--- a/betree/tests/scripts/ci-test.sh
+++ b/betree/tests/scripts/ci-test.sh
@@ -1,0 +1,5 @@
+#! /bin/env bash
+
+# num_thread=$(echo "$(cat /proc/meminfo | head -n 1 | xargs | cut -d ' ' -f 2) / 1024 / 1024 / 2" | bc)
+failed=$(cargo test -- --test-threads 1 -Z unstable-options --format json | grep suite | grep failed | jq '.failed')
+exit $failed


### PR DESCRIPTION
This PR adds a github action CI configuration for the `betree` crate.
Build, internal tests and integration tests will be executed in separate jobs and additionally give the name and output of each failed test including backtrace.