### PR TITLE
Match access patterns from objects to tiers

### DIFF
--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -339,7 +339,7 @@ impl<Message, Config: DatabaseBuilder> Dataset<Config, Message> {
         call(&mut self.inner.write().open_snapshots)
     }
 
-    pub(super) fn call_tree<F, R>(&self, call: F) -> R
+    pub(crate) fn call_tree<F, R>(&self, call: F) -> R
     where
         F: FnOnce(&MessageTree<Config::Dmu, Message>) -> R,
     {

--- a/betree/src/lib.rs
+++ b/betree/src/lib.rs
@@ -63,5 +63,5 @@ mod arbitrary;
 
 pub use self::{
     database::{Database, DatabaseConfiguration, Dataset, Error, Snapshot},
-    storage_pool::{AtomicStoragePreference, StoragePoolConfiguration, StoragePreference},
+    storage_pool::{AtomicStoragePreference, StoragePoolConfiguration, StoragePreference, PreferredAccessType},
 };

--- a/betree/src/storage_pool/configuration.rs
+++ b/betree/src/storage_pool/configuration.rs
@@ -11,7 +11,7 @@ use std::{
 /// Access pattern descriptor to differentiate and optimize drive usage. Useful
 /// when working with [crate::object::ObjectStore] with a defined with access pattern. Assignable to
 /// [TierConfiguration].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PreferredAccessType {
     /// The default access pattern. No assumptions are made.
     Unknown,

--- a/betree/src/storage_pool/configuration.rs
+++ b/betree/src/storage_pool/configuration.rs
@@ -3,6 +3,7 @@ use crate::vdev::{self, Dev, Leaf};
 use itertools::Itertools;
 use libc;
 use serde::{Deserialize, Serialize};
+use speedy::{Writable, Readable};
 use std::{
     fmt, fmt::Write, fs::OpenOptions, io, iter::FromIterator, os::unix::io::AsRawFd, path::PathBuf,
     slice,
@@ -11,7 +12,7 @@ use std::{
 /// Access pattern descriptor to differentiate and optimize drive usage. Useful
 /// when working with [crate::object::ObjectStore] with a defined with access pattern. Assignable to
 /// [TierConfiguration].
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Writable, Readable)]
 pub enum PreferredAccessType {
     /// The default access pattern. No assumptions are made.
     Unknown,

--- a/betree/src/storage_pool/mod.rs
+++ b/betree/src/storage_pool/mod.rs
@@ -11,7 +11,6 @@ use futures::{executor::block_on, prelude::*, TryFuture};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt;
 
-pub use configuration::{LeafVdev, Vdev};
 
 pub mod errors;
 pub use self::errors::*;
@@ -95,13 +94,16 @@ pub trait StoragePoolLayer: Clone + Send + Sync + 'static {
 
     /// Gather layer-specific metrics.
     fn metrics(&self) -> Self::Metrics;
+
+    /// Return a fitting [StoragePreference] to the given [PreferredAccessType].
+    fn access_type_preference(&self, t: PreferredAccessType) -> StoragePreference;
 }
 
 mod disk_offset;
 pub use self::disk_offset::DiskOffset;
 
 pub mod configuration;
-pub use self::configuration::{StoragePoolConfiguration, TierConfiguration};
+pub use self::configuration::{StoragePoolConfiguration, TierConfiguration, LeafVdev, Vdev, PreferredAccessType};
 
 mod unit;
 pub use self::unit::StoragePoolUnit;

--- a/betree/tests/src/configs.rs
+++ b/betree/tests/src/configs.rs
@@ -9,6 +9,30 @@ use betree_storage_stack::{
 
 use crate::TO_MEBIBYTE;
 
+pub fn access_specific_config() -> DatabaseConfiguration {
+    DatabaseConfiguration {
+        storage: StoragePoolConfiguration {
+            tiers: vec![
+                TierConfiguration {
+                    top_level_vdevs: vec![
+                        Vdev::Leaf(LeafVdev::Memory { mem: 2048 * TO_MEBIBYTE })
+                    ],
+                    preferred_access_type: betree_storage_stack::PreferredAccessType::RandomReadWrite
+                },
+                TierConfiguration {
+                    top_level_vdevs: vec![
+                        Vdev::Leaf(LeafVdev::Memory { mem: 2048 * TO_MEBIBYTE })
+                    ],
+                    preferred_access_type: betree_storage_stack::PreferredAccessType::SequentialReadWrite
+                },
+            ],
+            ..Default::default()
+        },
+        access_mode: AccessMode::OpenOrCreate,
+        ..Default::default()
+    }
+}
+
 pub fn migration_config_lfu_node() -> DatabaseConfiguration {
     migration_config_lfu(LfuMode::Node)
 }


### PR DESCRIPTION
This PR contains a basic matching to utilize the already existing `PreferredAccessType` in the storage configuration with an additional creation mode for objects.

The user perspective looks similiar to the following snippet:
```rust
let obj = os.create_object_with_access_type(b"foo", PreferredAccessType::RandomWrite);
```
The access type is internally translated to a storage preference indicating the current rank. We might also want to add the access type to the object metadata for future reference.

- [x] Implement object access type resolution
- [x] Add access type to metadata