### PR TITLE
ci: reduce number of quickcheck passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Run integration tests
         env:
           HAURA_NUM_THREAD: 1
+          QUICKCHECK_TESTS: 20
         run: |
           cd betree/tests
           ./scripts/ci-test.sh
@@ -119,6 +120,7 @@ jobs:
       - name: Run unit tests
         env:
           HAURA_NUM_THREAD: 8
+          QUICKCHECK_TESTS: 20
         run: |
           cd betree
           ./tests/scripts/ci-test.sh


### PR DESCRIPTION
This PR sets the `QUICKCHECK_TESTS` environment variable to a smaller value in the CI configuration. When running the tests this value is by default set to 100 which makes the testruns unbearably long (~20min) for relatively simple tests.

The `QUICKCHECK_TESTS` value determines the number of input variations which are used per test. If no variation fails, the test is considered successful. Given that large parts of our code base have experienced many iterations of tests already we probably don't need to worry too much when reducing this number to a more manageable workload in the CI.
This PR does not change anything in the normal developer experience, the default will still be used when executing tests locally.