### PR TITLE
tree: cleanup

### DIFF
--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -63,8 +63,6 @@ rand_xorshift = "0.3"
 quickcheck = "1"
 quickcheck_macros = "1"
 clap = "2.33"
-bencher = "0.1"
-
 criterion = "0.3"
 
 [features]

--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -17,6 +17,10 @@ harness = false
 name = "allocator"
 harness = false
 
+[[bench]]
+name = "tree"
+harness = false
+
 [dependencies]
 futures = { version = "0.3", features = ["thread-pool"] }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/betree/benches/tree.rs
+++ b/betree/benches/tree.rs
@@ -1,0 +1,35 @@
+use std::sync::atomic::AtomicU8;
+
+use bincode::serialized_size;
+use criterion::{criterion_group, criterion_main, Criterion};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Dummy<T> {
+    a: u32,
+    b: usize,
+    #[serde(skip)]
+    c: AtomicU8,
+    #[serde(skip)]
+    d: AtomicU8,
+    e: Vec<T>,
+    f: Vec<T>,
+}
+
+const DUMMY_NODE: Dummy<()> = Dummy {
+    a: 0,
+    b: 0,
+    c: AtomicU8::new(0),
+    d: AtomicU8::new(0),
+    e: vec![],
+    f: vec![],
+};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("serialized_size_internal_node", |b| {
+        b.iter(|| serialized_size(&DUMMY_NODE).unwrap() as usize)
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/betree/src/buffer.rs
+++ b/betree/src/buffer.rs
@@ -44,8 +44,8 @@ fn split_range_at(
     // No further implications should be expected as the only sequentially use of
     // this structure is in the [crate::vdev::Parity1] code.
     if range.start + mid < range.end {
-            // mid is in range
-            (range.start..range.start + mid, range.start + mid..range.end)
+        // mid is in range
+        (range.start..range.start + mid, range.start + mid..range.end)
     } else {
         // mid is past range
         (range.clone(), range.end..range.end)

--- a/betree/src/cache/clock_cache.rs
+++ b/betree/src/cache/clock_cache.rs
@@ -400,20 +400,3 @@ impl<K: Clone + Eq + Hash + Sync + Send + 'static, V: Sync + Send + SizeMut + 's
     #[inline(always)]
     fn verify(&mut self) {}
 }
-
-#[cfg(test)]
-mod tests {
-    use super::{Cache, ClockCache};
-    use bencher::{black_box, Bencher, benchmark_main, benchmark_group};
-
-    fn get_and_pin(b: &mut Bencher) {
-        let mut c = ClockCache::new(5);
-        c.insert(5, (), 1);
-        b.iter(|| {
-            black_box(c.get(&5, true));
-        });
-    }
-
-    benchmark_group!(benches, get_and_pin);
-    benchmark_main!(benches);
-}

--- a/betree/src/cache/clock_cache.rs
+++ b/betree/src/cache/clock_cache.rs
@@ -404,7 +404,7 @@ impl<K: Clone + Eq + Hash + Sync + Send + 'static, V: Sync + Send + SizeMut + 's
 #[cfg(test)]
 mod tests {
     use super::{Cache, ClockCache};
-    use bencher::{black_box, Bencher};
+    use bencher::{black_box, Bencher, benchmark_main, benchmark_group};
 
     fn get_and_pin(b: &mut Bencher) {
         let mut c = ClockCache::new(5);

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -246,7 +246,7 @@ impl<Config: DatabaseBuilder + Clone> Database<Config> {
             if let Some(ds) = ds.inner.try_read() {
                 self.sync_ds(ds.id, &ds.tree)?;
             }
-            return Ok(())
+            return Ok(());
         }
         // Deactivate the dataset for further modifications
         let ds = ds.inner.write();
@@ -355,9 +355,7 @@ impl<Message: MessageAction + 'static, Config: DatabaseBuilder> Dataset<Config, 
         key: K,
         msg: SlicedCowBytes,
     ) -> Result<()> {
-        self.inner
-            .read()
-            .insert_msg(key, msg)
+        self.inner.read().insert_msg(key, msg)
     }
 
     /// Inserts a message for the given key, allowing to override storage preference
@@ -375,9 +373,7 @@ impl<Message: MessageAction + 'static, Config: DatabaseBuilder> Dataset<Config, 
 
     /// Returns the value for the given key if existing.
     pub fn get<K: Borrow<[u8]>>(&self, key: K) -> Result<Option<SlicedCowBytes>> {
-        self.inner
-            .read()
-            .get(key)
+        self.inner.read().get(key)
     }
 
     /// Iterates over all key-value pairs in the given key range.
@@ -389,9 +385,7 @@ impl<Message: MessageAction + 'static, Config: DatabaseBuilder> Dataset<Config, 
         R: RangeBounds<K>,
         K: Borrow<[u8]> + Into<CowBytes>,
     {
-        self.inner
-            .read()
-            .range(range)
+        self.inner.read().range(range)
     }
 
     /// Returns the name of the data set.
@@ -402,9 +396,7 @@ impl<Message: MessageAction + 'static, Config: DatabaseBuilder> Dataset<Config, 
     #[allow(missing_docs)]
     #[cfg(feature = "internal-api")]
     pub fn tree_dump(&self) -> Result<impl serde::Serialize> {
-        self.inner
-            .read()
-            .tree_dump()
+        self.inner.read().tree_dump()
     }
 }
 
@@ -568,9 +560,7 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
     ///
     /// Note that any existing value will be overwritten.
     pub fn insert<K: Borrow<[u8]> + Into<CowBytes>>(&self, key: K, data: &[u8]) -> Result<()> {
-        self.inner
-            .read()
-            .insert(key, data)
+        self.inner.read().insert(key, data)
     }
 
     /// Upserts the value for the given key at the given offset.
@@ -597,18 +587,14 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
         data: &[u8],
         offset: u32,
     ) -> Result<()> {
-        self.inner
-            .read()
-            .upsert(key, data, offset)
+        self.inner.read().upsert(key, data, offset)
     }
 
     pub(crate) fn probe_storage_location<K: Borrow<[u8]>>(
         &self,
         key: K,
     ) -> Result<StoragePreference> {
-        self.inner
-            .read()
-            .probe_storage_location(key)
+        self.inner.read().probe_storage_location(key)
     }
 
     /// Given a key and storage preference notify for this entry to be moved to a new storage level.
@@ -622,22 +608,16 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
         key: K,
         pref: StoragePreference,
     ) -> Result<Option<()>> {
-        self.inner
-            .read()
-            .migrate(key, pref)
+        self.inner.read().migrate(key, pref)
     }
 
     /// Deletes the key-value pair if existing.
     pub fn delete<K: Borrow<[u8]> + Into<CowBytes>>(&self, key: K) -> Result<()> {
-        self.inner
-            .read()
-            .delete(key)
+        self.inner.read().delete(key)
     }
 
     pub(crate) fn free_space_tier(&self, pref: StoragePreference) -> Result<StorageInfo> {
-        self.inner
-            .read()
-            .free_space_tier(pref)
+        self.inner.read().free_space_tier(pref)
     }
 
     /// Removes all key-value pairs in the given key range.
@@ -646,9 +626,7 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
         R: RangeBounds<K>,
         K: Borrow<[u8]> + Into<CowBytes>,
     {
-        self.inner
-            .read()
-            .range_delete(range)
+        self.inner.read().range_delete(range)
     }
 
     /// Migrate a complete range of keys to another storage preference.
@@ -658,8 +636,6 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
         K: Borrow<[u8]> + Into<CowBytes>,
         R: RangeBounds<K>,
     {
-        self.inner
-            .read()
-            .migrate_range(range, pref)
+        self.inner.read().migrate_range(range, pref)
     }
 }

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -464,13 +464,6 @@ impl<Config: DatabaseBuilder> DatasetInner<Config, DefaultMessageAction> {
         self.upsert_with_pref(key, data, offset, StoragePreference::NONE)
     }
 
-    pub(crate) fn probe_storage_location<K: Borrow<[u8]>>(
-        &self,
-        key: K,
-    ) -> Result<StoragePreference> {
-        Ok(self.tree.probe_storage_level(key)?)
-    }
-
     /// Given a key and storage preference notify for this entry to be moved to a new storage level.
     /// If the key is already located on this layer no operation is performed and success is returned.
     ///
@@ -588,13 +581,6 @@ impl<Config: DatabaseBuilder> Dataset<Config, DefaultMessageAction> {
         offset: u32,
     ) -> Result<()> {
         self.inner.read().upsert(key, data, offset)
-    }
-
-    pub(crate) fn probe_storage_location<K: Borrow<[u8]>>(
-        &self,
-        key: K,
-    ) -> Result<StoragePreference> {
-        self.inner.read().probe_storage_location(key)
     }
 
     /// Given a key and storage preference notify for this entry to be moved to a new storage level.

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -62,17 +62,17 @@ impl<Config: DatabaseBuilder + Clone> Database<Config> {
         Ok(DatasetId::unpack(&data))
     }
 
-    /// A convenience instantiation of [Database::open_custom_dataset] with [DefaultMessageAction].
+    /// A convenience instantiation of [Database::open_custom_dataset] with the default message set.
     pub fn open_dataset(&mut self, name: &[u8]) -> Result<Dataset<Config>> {
         self.open_custom_dataset::<DefaultMessageAction>(name, StoragePreference::NONE)
     }
 
-    /// A convenience instantiation of [Database::create_custom_dataset] with [DefaultMessageAction].
+    /// A convenience instantiation of [Database::create_custom_dataset] with the default message set.
     pub fn create_dataset(&mut self, name: &[u8]) -> Result<()> {
         self.create_custom_dataset::<DefaultMessageAction>(name, StoragePreference::NONE)
     }
 
-    /// A convenience instantiation of [Database::open_or_create_custom_dataset] with [DefaultMessageAction].
+    /// A convenience instantiation of [Database::open_or_create_custom_dataset] with the default message set.
     pub fn open_or_create_dataset(&mut self, name: &[u8]) -> Result<Dataset<Config>> {
         self.open_or_create_custom_dataset::<DefaultMessageAction>(name, StoragePreference::NONE)
     }

--- a/betree/src/database/errors.rs
+++ b/betree/src/database/errors.rs
@@ -3,7 +3,7 @@ error_chain! {
     foreign_links {
         VdevError(crate::vdev::Error);
         StoragePoolError(crate::storage_pool::Error);
-        TreeError(crate::tree::Error);
+        TreeError(crate::tree::TreeError);
         SerializationError(::bincode::Error);
         ConfigurationError(crate::storage_pool::configuration::Error);
         Io(std::io::Error);

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         DmlWithStorageHints, Dmu, Handler as DmuHandler, HandlerDml,
     },
     metrics::{metrics_init, MetricsConfiguration},
-    migration::{DatabaseMsg, DmlMsg, MigrationPolicies, GlobalObjectId},
+    migration::{DatabaseMsg, DmlMsg, GlobalObjectId, MigrationPolicies},
     size::StaticSize,
     storage_pool::{
         DiskOffset, StoragePoolConfiguration, StoragePoolLayer, StoragePoolUnit,

--- a/betree/src/lib.rs
+++ b/betree/src/lib.rs
@@ -28,7 +28,7 @@ pub mod database;
 pub mod range_validation;
 pub mod size;
 pub mod storage_pool;
-pub mod tree;
+mod tree;
 pub mod vdev;
 
 pub mod metrics;

--- a/betree/src/lib.rs
+++ b/betree/src/lib.rs
@@ -28,7 +28,7 @@ pub mod database;
 pub mod range_validation;
 pub mod size;
 pub mod storage_pool;
-mod tree;
+pub mod tree;
 pub mod vdev;
 
 pub mod metrics;

--- a/betree/src/lib.rs
+++ b/betree/src/lib.rs
@@ -6,32 +6,13 @@
 // a maybe needed in the future basis.
 #![allow(dead_code)]
 
-extern crate bincode;
-extern crate byteorder;
-extern crate core;
 #[macro_use]
 extern crate error_chain;
-extern crate futures;
-extern crate itertools;
-extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate owning_ref;
-extern crate parking_lot;
-#[cfg(test)]
-extern crate quickcheck;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck_macros;
-#[cfg(test)]
-extern crate rand;
-extern crate seqlock;
-extern crate serde;
-extern crate stable_deref_trait;
-extern crate twox_hash;
-#[cfg(test)]
-#[macro_use]
-extern crate bencher;
 
 pub mod allocator;
 pub mod atomic_option;

--- a/betree/src/migration/lfu.rs
+++ b/betree/src/migration/lfu.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::{
     errors::Result, reinforcment_learning::open_file_buf_write, DatabaseMsg, DmlMsg,
-    MigrationConfig, GlobalObjectId,
+    GlobalObjectId, MigrationConfig,
 };
 
 #[derive(Clone, Debug, Hash, PartialEq)]

--- a/betree/src/migration/mod.rs
+++ b/betree/src/migration/mod.rs
@@ -236,7 +236,12 @@ pub(crate) trait MigrationPolicy<C: DatabaseBuilder + Clone> {
 
             use crate::database::StorageInfo;
 
-            let threshold: Vec<f32> = self.config().migration_threshold.iter().map(|val| val.clamp(0.0, 1.0)).collect();
+            let threshold: Vec<f32> = self
+                .config()
+                .migration_threshold
+                .iter()
+                .map(|val| val.clamp(0.0, 1.0))
+                .collect();
             let infos: Vec<(u8, StorageInfo)> = (0u8..NUM_STORAGE_CLASSES as u8)
                 .filter_map(|class| {
                     self.dmu()
@@ -268,12 +273,14 @@ pub(crate) trait MigrationPolicy<C: DatabaseBuilder + Clone> {
                 .iter()
                 .tuple_windows()
                 .filter(|((high_tier, high_info), (low_tier, low_info))| {
-                    high_info.percent_full() > threshold[*high_tier as usize] && low_info.percent_full() < threshold[*low_tier as usize]
+                    high_info.percent_full() > threshold[*high_tier as usize]
+                        && low_info.percent_full() < threshold[*low_tier as usize]
                 })
             {
-                let desired: Block<u64> =
-                    Block((high_info.total.as_u64() as f32 * (1.0 - threshold[*high_tier as usize])) as u64)
-                        - high_info.free.as_u64();
+                let desired: Block<u64> = Block(
+                    (high_info.total.as_u64() as f32 * (1.0 - threshold[*high_tier as usize]))
+                        as u64,
+                ) - high_info.free.as_u64();
                 self.demote(*high_tier, desired)?;
             }
             self.metrics()?;

--- a/betree/src/migration/msg.rs
+++ b/betree/src/migration/msg.rs
@@ -23,7 +23,6 @@ pub enum DmlMsg {
     // The three base operations of our store.
     // Largely relevant for clearing, and frequency determination in LRU, LFU,
     // FIFO and other policies
-
     /// A fetch operation from disk has been performed.
     Fetch(OpInfo),
     /// A write operation to disk has been performed.
@@ -31,7 +30,6 @@ pub enum DmlMsg {
     /// A node has been completely removed from the storage stack and can no
     /// longer be referenced.
     Remove(OpInfo),
-
     // /// Initial message at the beginning of an session.
     // Discover(DiskOffset),
 }

--- a/betree/src/migration/reinforcment_learning.rs
+++ b/betree/src/migration/reinforcment_learning.rs
@@ -17,7 +17,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use super::{DatabaseMsg, DmlMsg, MigrationConfig, MigrationPolicy, GlobalObjectId};
+use super::{DatabaseMsg, DmlMsg, GlobalObjectId, MigrationConfig, MigrationPolicy};
 // This file contains a migration policy based on reinforcement learning.
 // We based our approach on the description of
 // https://doi.org/10.1109/TKDE.2022.3176753 and aim to use them for object
@@ -154,7 +154,9 @@ mod learning {
             }
         }
 
-        pub fn coldest(&mut self) -> Option<(GlobalObjectId, (FileProperties, Option<Vec<Request>>))> {
+        pub fn coldest(
+            &mut self,
+        ) -> Option<(GlobalObjectId, (FileProperties, Option<Vec<Request>>))> {
             self.files
                 .iter()
                 .min_by(|(_, v_left), (_, v_right)| v_left.hotness.0.total_cmp(&v_right.hotness.0))

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -433,6 +433,7 @@ impl<'os, Config: DatabaseBuilder + Clone> ObjectStore<Config> {
         let oid = loop {
             let oid = ObjectId(self.object_id_counter.fetch_add(1, Ordering::SeqCst));
 
+            // FIXME: Ensure that OID is valid without disk sanity checks.
             // check for existing object with this oid
             if let Some(_existing_chunk) = self.data.get(object_chunk_key(oid, 0))? {
                 warn!("oid collision: {:?}", oid);

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -1040,15 +1040,6 @@ impl<'ds, Config: DatabaseBuilder + Clone> ObjectHandle<'ds, Config> {
         Ok(Box::new(iter))
     }
 
-    /// Try to probe information about the current storage level of the object.
-    /// FIXME: On sparse objects we don't know which chunk really exists, we
-    /// assume here the first, but this can be wrong.
-    pub(crate) fn probe_storage_level(&self, offset: u64) -> Result<StoragePreference> {
-        let chunk = ChunkRange::from_byte_bounds(offset, 1);
-        let key = object_chunk_key(self.object.id, chunk.start.chunk_id);
-        self.store.data.probe_storage_location(&key[..])
-    }
-
     /// Migrate the whole object to a specified storage preference and write all future accesses to the same storage
     /// tier.
     pub fn migrate(&mut self, pref: StoragePreference) -> Result<()> {

--- a/betree/src/storage_pool/storage_preference.rs
+++ b/betree/src/storage_pool/storage_preference.rs
@@ -196,6 +196,12 @@ impl PartialEq for AtomicStoragePreference {
     }
 }
 
+impl Default for AtomicStoragePreference {
+    fn default() -> Self {
+        Self::unknown()
+    }
+}
+
 /// An upper bound reflecting the optimized choice of storage determined by the
 /// automated migration policy, in contrast to the lower bound by
 /// [StoragePreference]. Acts as a neutral element when set to

--- a/betree/src/storage_pool/storage_preference.rs
+++ b/betree/src/storage_pool/storage_preference.rs
@@ -44,7 +44,7 @@ impl StoragePreference {
 
     /// Construct a new [StoragePreference], for a given class.
     /// Panics if `class > 3`.
-    pub fn new(class: u8) -> Self {
+    pub const fn new(class: u8) -> Self {
         assert!(class <= 3);
         Self(class)
     }
@@ -75,10 +75,10 @@ impl StoragePreference {
         }
     }
 
-    pub(crate) fn as_u8(self) -> u8 {
+    pub(crate) const fn as_u8(self) -> u8 {
         self.0
     }
-    pub(crate) fn from_u8(u: u8) -> Self {
+    pub(crate) const fn from_u8(u: u8) -> Self {
         debug_assert!(u == u8::MAX - 1 || u <= 3);
         Self(u)
     }
@@ -120,11 +120,11 @@ pub struct AtomicStoragePreference(AtomicU8);
 
 #[allow(missing_docs)]
 impl AtomicStoragePreference {
-    pub fn known(class: StoragePreference) -> Self {
+    pub const fn known(class: StoragePreference) -> Self {
         Self(AtomicU8::new(class.0))
     }
 
-    pub fn unknown() -> Self {
+    pub const fn unknown() -> Self {
         Self(AtomicU8::new(u8::MAX))
     }
 
@@ -252,6 +252,10 @@ impl From<&AtomicSystemStoragePreference> for AtomicStoragePreference {
 }
 
 impl AtomicSystemStoragePreference {
+    pub const fn none() -> Self {
+        Self(AtomicU8::new(StoragePreference::NONE.as_u8()))
+    }
+
     pub fn set(&self, pref: StoragePreference) {
         self.0.store(pref.as_u8(), Ordering::SeqCst);
     }

--- a/betree/src/tree/default_message_action.rs
+++ b/betree/src/tree/default_message_action.rs
@@ -373,12 +373,13 @@ mod tests {
                 MsgType::Upsert => {
                     let offsets = (0..10).map(|_| rng.gen_range(0..10)).collect::<Vec<u32>>();
                     let data: Vec<_> = Arbitrary::arbitrary(g);
-                    let msgs = (0..10).zip(offsets).map(|(_, offset)| {
-                        Upsert::Bytes {
+                    let msgs = (0..10)
+                        .zip(offsets)
+                        .map(|(_, offset)| Upsert::Bytes {
                             offset_bytes: offset,
                             data: &data,
-                        }
-                    }).collect::<Vec<Upsert>>();
+                        })
+                        .collect::<Vec<Upsert>>();
                     DefaultMessageActionMsg(DefaultMessageAction::build_upsert_msg(&msgs))
                 }
                 MsgType::OverwriteNone => {

--- a/betree/src/tree/default_message_action.rs
+++ b/betree/src/tree/default_message_action.rs
@@ -371,15 +371,15 @@ mod tests {
             let b = MsgType::from(rng.gen_range(0..3));
             match b {
                 MsgType::Upsert => {
-                    // TODO multiple?
-                    let offset = rng.gen_range(0..10);
+                    let offsets = (0..10).map(|_| rng.gen_range(0..10)).collect::<Vec<u32>>();
                     let data: Vec<_> = Arbitrary::arbitrary(g);
-                    DefaultMessageActionMsg(DefaultMessageAction::build_upsert_msg(&[
+                    let msgs = (0..10).zip(offsets).map(|(_, offset)| {
                         Upsert::Bytes {
                             offset_bytes: offset,
                             data: &data,
-                        },
-                    ]))
+                        }
+                    }).collect::<Vec<Upsert>>();
+                    DefaultMessageActionMsg(DefaultMessageAction::build_upsert_msg(&msgs))
                 }
                 MsgType::OverwriteNone => {
                     DefaultMessageActionMsg(DefaultMessageAction::delete_msg())

--- a/betree/src/tree/errors.rs
+++ b/betree/src/tree/errors.rs
@@ -1,13 +1,17 @@
-#![allow(missing_docs, unused_doc_comments)]
-error_chain! {
-    types {
-        Error, ErrorKind, ResultExt;
-    }
-    foreign_links {
-        DmuError(crate::data_management::Error);
-    }
-    errors {
-        EmptyKey
-        InvalidRange
-    }
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TreeError {
+    #[error("Storage operation could not be performed")]
+    DmuError {
+        #[from]
+        source: crate::data_management::Error,
+        // TODO: Once we migrate data_management module to thiserror we may use
+        // the backtrace propagation feature
+        // backtrace: Backtrace,
+    },
+    #[error("A key of length was given")]
+    EmptyKey,
+    #[error("Invalid range specification")]
+    InvalidRange,
 }

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -1,3 +1,7 @@
+//! Implementation of a message buffering node wrapper.
+//!
+//! Encapsulating common nodes like [super::internal::InternalNode] and
+//! [super::leaf::LeafNode].
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::HasStoragePreference,
@@ -70,6 +74,7 @@ impl<N: HasStoragePreference> HasStoragePreference for ChildBuffer<N> {
 }
 
 mod ser_np {
+    //! Serialization utilities of a node pointer type.
     use super::RwLock;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -214,7 +214,6 @@ impl<N> ChildBuffer<N> {
 
         self.messages_preference.upgrade(keyinfo.storage_preference);
 
-        // TODO
         match self.buffer.entry(key.clone()) {
             Entry::Vacant(e) => {
                 let size_delta = key_size + msg.size() + keyinfo.size();

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -250,7 +250,16 @@ impl<N> ChildBuffer<N> {
 
 impl<N> ChildBuffer<N> {
     pub fn range_delete(&mut self, start: &[u8], end: Option<&[u8]>) -> usize {
-        // TODO https://github.com/rust-lang/rust/issues/42849
+        // Context: Previously we mentioned the usage of a drain filter here and
+        // linked to an existing issue of how it is missing from the standard
+        // library.
+        //
+        // Adding a drain filter here would make things easier from the code
+        // perspective, but with the generic predicate, we cannot utilize the
+        // nice property of the BTreeMap that data is ordered and the traversal
+        // of the tree can be nicely restrictred with a proper range. Due to
+        // this I changed the T0D0 placed here to this very explanation you are
+        // reading.
         let mut size_delta = 0;
         let range = (
             Bound::Included(start),

--- a/betree/src/tree/imp/derivate_ref.rs
+++ b/betree/src/tree/imp/derivate_ref.rs
@@ -33,7 +33,6 @@ pub struct DerivateRef<T, U> {
 }
 
 impl<T: StableDeref + DerefMut, U> DerivateRef<T, TakeChildBuffer<'static, U>> {
-
     /// Unsafe conversions of a limited life-time reference in [TakeChildBuffer]
     /// to a static one. This is only ever safe in the internal context of [DerivateRef].
     pub fn try_new<F>(mut owner: T, f: F) -> Result<Self, T>

--- a/betree/src/tree/imp/derivate_ref.rs
+++ b/betree/src/tree/imp/derivate_ref.rs
@@ -1,0 +1,71 @@
+//! Implementation of derivative and original structure container to ensure lifetime
+//! guarantees.
+use stable_deref_trait::StableDeref;
+use std::{
+    mem::transmute,
+    ops::{Deref, DerefMut},
+};
+
+use crate::cache::AddSize;
+
+use super::internal::TakeChildBuffer;
+
+/// A reference allowing for a derivative of the original structure to be stored
+/// alongside the original. Helpful if a derivative of the original is dependent
+/// on its lifetime.
+///
+/// This structures differs from somthing like an owning reference as that we
+/// are not dependent on actual references when considering the reference or
+/// derivative of a type. For example when we perform an operation one value o
+/// (owner) to get some value d (derivative) which is it's own independent type
+/// with references to o we cannot store this with a simple map in owning ref.
+///
+/// ```rust,ignore
+/// // Does not compile 😿
+/// let owning_ref = OwningRef::new(o).map(|o| &o.some_transition());
+///                                         // ^-- we can't a reference from a temporary value
+/// // Does compile 😸
+/// let derivate_ref = DerivateRef::try_new(o, |o| o.some_transition())
+/// ```
+pub struct DerivateRef<T, U> {
+    inner: U,
+    owner: T,
+}
+
+impl<T: StableDeref + DerefMut, U> DerivateRef<T, TakeChildBuffer<'static, U>> {
+
+    /// Unsafe conversions of a limited life-time reference in [TakeChildBuffer]
+    /// to a static one. This is only ever safe in the internal context of [DerivateRef].
+    pub fn try_new<F>(mut owner: T, f: F) -> Result<Self, T>
+    where
+        F: for<'a> FnOnce(&'a mut T::Target) -> Option<TakeChildBuffer<'a, U>>,
+    {
+        match unsafe { transmute(f(&mut owner)) } {
+            None => Err(owner),
+            Some(inner) => Ok(DerivateRef { owner, inner }),
+        }
+    }
+
+    pub fn into_owner(self) -> T {
+        self.owner
+    }
+}
+
+impl<T: AddSize, U> AddSize for DerivateRef<T, U> {
+    fn add_size(&self, size_delta: isize) {
+        self.owner.add_size(size_delta);
+    }
+}
+
+impl<T, U> Deref for DerivateRef<T, U> {
+    type Target = U;
+    fn deref(&self) -> &U {
+        &self.inner
+    }
+}
+
+impl<T, U> DerefMut for DerivateRef<T, U> {
+    fn deref_mut(&mut self) -> &mut U {
+        &mut self.inner
+    }
+}

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -130,7 +130,7 @@ where
                     let mut sibling = self.get_mut_node(m.sibling_node_pointer())?;
                     let left;
                     let right;
-                    // TODO deallocation
+                    // TODO deallocation of the now empty leaf
                     if m.is_right_sibling() {
                         left = &mut child;
                         right = &mut sibling;

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -6,7 +6,8 @@
 use std::borrow::Borrow;
 
 use super::{
-    child_buffer::ChildBuffer, internal::TakeChildBuffer, FillUpResult, Inner, Node, Tree, derivate_ref::DerivateRef,
+    child_buffer::ChildBuffer, derivate_ref::DerivateRef, internal::TakeChildBuffer, FillUpResult,
+    Inner, Node, Tree,
 };
 use crate::{
     cache::AddSize,
@@ -50,7 +51,9 @@ where
     pub(super) fn rebalance_tree(
         &self,
         mut node: X::CacheValueRefMut,
-        mut parent: Option<DerivateRef<X::CacheValueRefMut, TakeChildBuffer<'static, ChildBuffer<R>>>>,
+        mut parent: Option<
+            DerivateRef<X::CacheValueRefMut, TakeChildBuffer<'static, ChildBuffer<R>>>,
+        >,
     ) -> Result<(), TreeError> {
         loop {
             if !node.is_too_large() {
@@ -65,24 +68,24 @@ where
                 node.actual_size()
             );
             // 1. Select the largest child buffer which can be flushed.
-            let mut child_buffer = match DerivateRef::try_new(node, |node| node.try_find_flush_candidate())
-            {
-                // 1.1. If there is none we have to split the node.
-                Err(_node) => match parent {
-                    None => {
-                        self.split_root_node(_node);
-                        return Ok(());
-                    }
-                    Some(ref mut parent) => {
-                        let (next_node, size_delta) = self.split_node(_node, parent)?;
-                        parent.add_size(size_delta);
-                        node = next_node;
-                        continue;
-                    }
-                },
-                // 1.2. If successful we flush in the following steps to this node.
-                Ok(selected_child_buffer) => selected_child_buffer,
-            };
+            let mut child_buffer =
+                match DerivateRef::try_new(node, |node| node.try_find_flush_candidate()) {
+                    // 1.1. If there is none we have to split the node.
+                    Err(_node) => match parent {
+                        None => {
+                            self.split_root_node(_node);
+                            return Ok(());
+                        }
+                        Some(ref mut parent) => {
+                            let (next_node, size_delta) = self.split_node(_node, parent)?;
+                            parent.add_size(size_delta);
+                            node = next_node;
+                            continue;
+                        }
+                    },
+                    // 1.2. If successful we flush in the following steps to this node.
+                    Ok(selected_child_buffer) => selected_child_buffer,
+                };
             let mut child = self.get_mut_node(child_buffer.node_pointer_mut())?;
             // 2. Iterate down to child if too large
             if !child.is_leaf() && child.is_too_large() {
@@ -142,7 +145,9 @@ where
                         FillUpResult::Merged { size_delta } => {
                             left.add_size(size_delta);
                             right.add_size(-size_delta);
-                            let MergeChildResult {old_np, size_delta, ..} = m.merge_children();
+                            let MergeChildResult {
+                                old_np, size_delta, ..
+                            } = m.merge_children();
                             self.dml.remove(old_np);
                             size_delta
                         }

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -130,7 +130,6 @@ where
                     let mut sibling = self.get_mut_node(m.sibling_node_pointer())?;
                     let left;
                     let right;
-                    // TODO deallocation of the now empty leaf
                     if m.is_right_sibling() {
                         left = &mut child;
                         right = &mut sibling;
@@ -142,7 +141,9 @@ where
                         FillUpResult::Merged { size_delta } => {
                             left.add_size(size_delta);
                             right.add_size(-size_delta);
-                            m.merge_children().size_delta
+                            let MergeChildResult {old_np, size_delta, ..} = m.merge_children();
+                            self.dml.remove(old_np);
+                            size_delta
                         }
                         FillUpResult::Rebalanced {
                             pivot_key,

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -1,3 +1,8 @@
+//! Implementation of the tree-wide rebalancing and flushing logic.
+//!
+//! Calling [Tree::rebalance_tree] is not only possible with the root node but may be
+//! applied to a variety of nodes given that their parent node is correctly
+//! given. Use with caution.
 use super::{
     child_buffer::ChildBuffer, internal::TakeChildBuffer, FillUpResult, Inner, Node, Tree,
 };
@@ -181,12 +186,16 @@ where
     }
 }
 
+/// Simple owning reference handle. Internally used here.
 pub struct Ref<T, U> {
     inner: U,
     owner: T,
 }
 
 impl<T: StableDeref + DerefMut, U> Ref<T, TakeChildBuffer<'static, U>> {
+
+    /// Unsafe conversions of a limited life-time reference in [TakeChildBuffer]
+    /// to a static one. This is only ever safe in the internal context of [Ref].
     pub fn try_new<F>(mut owner: T, f: F) -> Result<Self, T>
     where
         F: for<'a> FnOnce(&'a mut T::Target) -> Option<TakeChildBuffer<'a, U>>,

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -51,7 +51,7 @@ where
         &self,
         mut node: X::CacheValueRefMut,
         mut parent: Option<DerivateRef<X::CacheValueRefMut, TakeChildBuffer<'static, ChildBuffer<R>>>>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), TreeError> {
         loop {
             if !node.is_too_large() {
                 return Ok(());

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -18,6 +18,7 @@ pub(super) struct InternalNode<T> {
     entries_size: usize,
     #[serde(skip)]
     system_storage_preference: AtomicSystemStoragePreference,
+    #[serde(skip)]
     pref: AtomicStoragePreference,
     pub(super) pivot: Vec<CowBytes>,
     children: Vec<T>,

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -328,14 +328,14 @@ impl<T: Size> InternalNode<T> {
         let size_delta = entries_size + pivot_key.size();
         self.entries_size -= size_delta;
 
-        // Neither side is sure about its current storage preference after a split
-        // TODO: One may argue to precautiously copy the system preference of the former node here.
         let right_sibling = InternalNode {
             level: self.level,
             entries_size,
             pivot,
             children,
-            system_storage_preference: AtomicSystemStoragePreference::from(StoragePreference::NONE),
+            // Copy the system storage preference of the other node as we cannot
+            // be sure which key was targeted by recorded accesses.
+            system_storage_preference: self.system_storage_preference.clone(),
         };
         (right_sibling, pivot_key, -(size_delta as isize))
     }

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -367,7 +367,7 @@ where
         }
     }
 
-    pub fn try_flush(
+    pub fn try_find_flush_candidate(
         &mut self,
         min_flush_size: usize,
         max_node_size: usize,

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -158,7 +158,6 @@ impl<T> InternalNode<T> {
 
 impl<N> InternalNode<ChildBuffer<N>> {
     pub fn get(&self, key: &[u8]) -> (&RwLock<N>, Option<(KeyInfo, SlicedCowBytes)>) {
-        // TODO Merge range messages into msg stream
         let child = &self.children[self.idx(key)];
 
         let msg = child.get(key).cloned();
@@ -185,7 +184,6 @@ impl<N> InternalNode<ChildBuffer<N>> {
         right_pivot_key: &mut Option<CowBytes>,
         all_msgs: &mut BTreeMap<CowBytes, Vec<(KeyInfo, SlicedCowBytes)>>,
     ) -> &RwLock<N> {
-        // TODO Merge range messages into msg stream
         let idx = self.idx(key);
         if idx > 0 {
             *left_pivot_key = Some(self.pivot[idx - 1].clone());

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -6,7 +6,7 @@ use crate::{
     size::{Size, SizeMut, StaticSize},
     storage_pool::{AtomicSystemStoragePreference, StoragePreferenceBound},
     tree::{KeyInfo, MessageAction},
-    StoragePreference, AtomicStoragePreference,
+    AtomicStoragePreference, StoragePreference,
 };
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -70,7 +70,9 @@ impl<T: HasStoragePreference> HasStoragePreference for InternalNode<T> {
     // Furthermore, have a look at the HasStoragePreference trait.
     // We might perform way more operations than really should.
     fn current_preference(&self) -> Option<StoragePreference> {
-        self.pref.as_option().map(|pref| self.system_storage_preference.weak_bound(&pref))
+        self.pref
+            .as_option()
+            .map(|pref| self.system_storage_preference.weak_bound(&pref))
         // Some(
         //     self.system_storage_preference
         //         .weak_bound(&self.recalculate()),
@@ -89,7 +91,8 @@ impl<T: HasStoragePreference> HasStoragePreference for InternalNode<T> {
     }
 
     fn correct_preference(&self) -> StoragePreference {
-        self.system_storage_preference.weak_bound(&self.recalculate())
+        self.system_storage_preference
+            .weak_bound(&self.recalculate())
     }
 
     fn system_storage_preference(&self) -> StoragePreference {

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -467,8 +467,15 @@ impl<'a, N> PrepareMergeChild<'a, ChildBuffer<N>> {
         self.pivot_key_idx != self.other_child_idx
     }
 }
+
+pub(super) struct MergeChildResult<NP> {
+    pub(super) pivot_key: CowBytes,
+    pub(super) old_np: NP,
+    pub(super) size_delta: isize,
+}
+
 impl<'a, N: Size + HasStoragePreference> PrepareMergeChild<'a, ChildBuffer<N>> {
-    pub(super) fn merge_children(self) -> (CowBytes, N, isize) {
+    pub(super) fn merge_children(self) -> MergeChildResult<N> {
         let mut right_sibling = self.node.children.remove(self.pivot_key_idx + 1);
         let pivot_key = self.node.pivot.remove(self.pivot_key_idx);
         let size_delta =
@@ -481,11 +488,11 @@ impl<'a, N: Size + HasStoragePreference> PrepareMergeChild<'a, ChildBuffer<N>> {
             .messages_preference
             .upgrade_atomic(&right_sibling.messages_preference);
 
-        (
+        MergeChildResult {
             pivot_key,
-            right_sibling.node_pointer.into_inner(),
-            -(size_delta as isize),
-        )
+            old_np: right_sibling.node_pointer.into_inner(),
+            size_delta: -(size_delta as isize),
+        }
     }
 }
 

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -66,17 +66,10 @@ impl<T: Size> Size for InternalNode<T> {
 }
 
 impl<T: HasStoragePreference> HasStoragePreference for InternalNode<T> {
-    // TODO: This should by convention really not recalculte based on this request
-    // Furthermore, have a look at the HasStoragePreference trait.
-    // We might perform way more operations than really should.
     fn current_preference(&self) -> Option<StoragePreference> {
         self.pref
             .as_option()
             .map(|pref| self.system_storage_preference.weak_bound(&pref))
-        // Some(
-        //     self.system_storage_preference
-        //         .weak_bound(&self.recalculate()),
-        // )
     }
 
     fn recalculate(&self) -> StoragePreference {

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -1,3 +1,4 @@
+//! Implementation of the [InternalNode] node type.
 use super::child_buffer::ChildBuffer;
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -152,8 +152,8 @@ impl LeafNode {
         min_size: usize,
         max_size: usize,
     ) -> (CowBytes, isize) {
-        assert!(self.size() > max_size);
-        assert!(right_sibling.entries_size == 0);
+        debug_assert!(self.size() > max_size);
+        debug_assert!(right_sibling.entries_size == 0);
 
         let mut sibling_size = 0;
         let mut sibling_pref = StoragePreference::NONE;

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -497,10 +497,4 @@ mod tests {
         assert_eq!(this, leaf_node);
         TestResult::passed()
     }
-
-    // TODO
-    // check size deltas for various operations (insert, delete, rebalance,
-    // fill_up...)
-    // check insert
-    // check rebalance, fill_up
 }

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -1,4 +1,4 @@
-use super::FillUpResult;
+//! Implementation of the [LeafNode] node type.
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::HasStoragePreference,
@@ -18,6 +18,18 @@ pub(super) struct LeafNode {
     system_storage_preference: AtomicSystemStoragePreference,
     entries_size: usize,
     entries: BTreeMap<CowBytes, (KeyInfo, SlicedCowBytes)>,
+}
+
+/// Case-dependent outcome of a rebalance operation.
+#[derive(Debug)]
+pub(super) enum FillUpResult {
+    Rebalanced {
+        pivot_key: CowBytes,
+        size_delta: isize,
+    },
+    Merged {
+        size_delta: isize,
+    },
 }
 
 impl Size for LeafNode {

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -1,3 +1,4 @@
+//! Implementation of tree structures.
 use self::{
     derivate_ref::DerivateRef,
     node::{ApplyResult, GetResult},

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -16,10 +16,10 @@ use crate::{
     tree::MessageAction,
     StoragePreference,
 };
+use leaf::FillUpResult;
 use owning_ref::OwningRef;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use std::{borrow::Borrow, marker::PhantomData, mem, ops::RangeBounds};
-use leaf::FillUpResult;
 
 /// Additional information for a single entry. Concerns meta information like
 /// the desired storage level of a key.
@@ -247,7 +247,10 @@ where
         self.dml.try_get_mut(np_ref.get_mut())
     }
 
-    fn get_mut_node_mut(&self, np_ref: &mut X::ObjectRef) -> Result<X::CacheValueRefMut, TreeError> {
+    fn get_mut_node_mut(
+        &self,
+        np_ref: &mut X::ObjectRef,
+    ) -> Result<X::CacheValueRefMut, TreeError> {
         if let Some(node) = self.dml.try_get_mut(np_ref) {
             return Ok(node);
         }
@@ -444,7 +447,7 @@ where
         K: Borrow<[u8]> + Into<CowBytes>,
     {
         if key.borrow().is_empty() {
-            return Err(TreeError::EmptyKey)
+            return Err(TreeError::EmptyKey);
         }
         let mut parent = None;
         let mut node = {
@@ -510,7 +513,7 @@ where
         Self: Clone,
     {
         if !is_inclusive_non_empty(&range) {
-            return Err(TreeError::InvalidRange)
+            return Err(TreeError::InvalidRange);
         }
         Ok(RangeIterator::new(range, self.clone()))
     }
@@ -545,6 +548,7 @@ where
 }
 
 mod child_buffer;
+mod derivate_ref;
 mod flush;
 mod internal;
 mod leaf;
@@ -552,6 +556,5 @@ mod node;
 mod packed;
 mod range;
 mod split;
-mod derivate_ref;
 
 pub use self::{node::Node, range::RangeIterator};

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -474,7 +474,7 @@ where
             unimplemented!();
         }
 
-        self.fixup_foo(node, parent)?;
+        self.rebalance_tree(node, parent)?;
 
         // TODO evict?
         // Is this really necessary here? Or is waiting until the next sync fine?

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -274,7 +274,7 @@ where
         start: &[u8],
         end: Option<&[u8]>,
     ) -> Result<(), Error> {
-        // TODO rebalance/merge nodes
+        // T0D0 rebalance/merge nodes
         loop {
             let (size_delta, next_node) = {
                 let level = node.level();
@@ -475,14 +475,17 @@ where
         node.add_size(added_size);
 
         if parent.is_none() && node.root_needs_merge() {
-            // TODO merge
+            // TODO Merge, this is not implemented with the 'rebalance_tree'
+            // method. Since the root has a fanout of 1 at this point, merge all
+            // messages downwards and set leaf as root?
             unimplemented!();
         }
 
         self.rebalance_tree(node, parent)?;
 
-        // TODO evict?
-        // Is this really necessary here? Or is waiting until the next sync fine?
+        // All non-root trees will start the eviction process.
+        // TODO: Is the eviction on root trees harmful? Evictions started by
+        // other trees will evict root nodes anyway.
         if self.evict {
             self.dml.evict()?;
         }

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -372,25 +372,6 @@ where
         }
     }
 
-    pub(crate) fn probe_storage_level<K: Borrow<[u8]>>(
-        &self,
-        key: K,
-    ) -> Result<StoragePreference, TreeError> {
-        let key = key.borrow();
-        let mut node = self.get_root_node()?;
-        let mut last_pointer = node.correct_preference();
-        Ok(loop {
-            let next_node = match node.probe_storage_level(key) {
-                node::ProbeResult::Leaf => break last_pointer,
-                node::ProbeResult::NextNode(np) => {
-                    last_pointer = np.read().correct_preference();
-                    self.get_node(np)?
-                }
-            };
-            node = next_node;
-        })
-    }
-
     /// "Piercing" update, with insertion logic of a B-Tree.
     /// To keep data sanity only modification of the key information is allowed
     /// and all key infos on the paths will be updated to reflect this change.

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -21,8 +21,13 @@ use std::{borrow::Borrow, marker::PhantomData, mem, ops::RangeBounds};
 
 #[derive(Debug)]
 enum FillUpResult {
-    Rebalanced(CowBytes),
-    Merged,
+    Rebalanced {
+        pivot_key: CowBytes,
+        size_delta: isize,
+    },
+    Merged {
+        size_delta: isize,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -18,18 +18,10 @@ use crate::{
 use owning_ref::OwningRef;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use std::{borrow::Borrow, marker::PhantomData, mem, ops::RangeBounds};
+use leaf::FillUpResult;
 
-#[derive(Debug)]
-enum FillUpResult {
-    Rebalanced {
-        pivot_key: CowBytes,
-        size_delta: isize,
-    },
-    Merged {
-        size_delta: isize,
-    },
-}
-
+/// Additional information for a single entry. Concerns meta information like
+/// the desired storage level of a key.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct KeyInfo {
     storage_preference: StoragePreference,

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -1,5 +1,5 @@
 use self::{
-    flush::Ref,
+    derivate_ref::DerivateRef,
     node::{ApplyResult, GetResult},
 };
 use super::{
@@ -447,7 +447,7 @@ where
         let mut node = {
             let mut node = self.get_mut_root_node()?;
             loop {
-                match Ref::try_new(node, |node| node.try_walk(key.borrow())) {
+                match DerivateRef::try_new(node, |node| node.try_walk(key.borrow())) {
                     Ok(mut child_buffer) => {
                         if let Some(child) = self.try_get_mut_node(child_buffer.node_pointer_mut())
                         {
@@ -547,5 +547,6 @@ mod node;
 mod packed;
 mod range;
 mod split;
+mod derivate_ref;
 
 pub use self::{node::Node, range::RangeIterator};

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -465,7 +465,7 @@ impl<N: StaticSize + HasStoragePreference> Node<N> {
                 (Node(Leaf(node)), pivot_key, size_delta)
             }
             Internal(ref mut internal) => {
-                assert!(
+                debug_assert!(
                     internal.fanout() >= 2 * MIN_FANOUT,
                     "internal split failed due to low fanout: {}, size: {}, actual_size: {:?}",
                     internal.fanout(),

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -154,11 +154,11 @@ impl<N: StaticSize + HasStoragePreference> Node<N> {
         }
     }
 
-    pub(super) fn try_flush(&mut self) -> Option<TakeChildBuffer<ChildBuffer<N>>> {
+    pub(super) fn try_find_flush_candidate(&mut self) -> Option<TakeChildBuffer<ChildBuffer<N>>> {
         match self.0 {
             Leaf(_) | PackedLeaf(_) => None,
             Internal(ref mut internal) => {
-                internal.try_flush(MIN_FLUSH_SIZE, MAX_INTERNAL_NODE_SIZE, MIN_FANOUT)
+                internal.try_find_flush_candidate(MIN_FLUSH_SIZE, MAX_INTERNAL_NODE_SIZE, MIN_FANOUT)
             }
         }
     }

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -398,14 +398,6 @@ impl<N: HasStoragePreference + StaticSize> Node<N> {
             })
     }
 
-    pub(super) fn probe_storage_level(&self, key: &[u8]) -> ProbeResult<N> {
-        match self.0 {
-            PackedLeaf(_) => ProbeResult::Leaf,
-            Leaf(_) => ProbeResult::Leaf,
-            Internal(ref internal) => ProbeResult::NextNode(internal.probe_storage_level(key)),
-        }
-    }
-
     pub(super) fn apply_with_info(
         &mut self,
         key: &[u8],

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -1,3 +1,4 @@
+//! Implementation of the generic node wrapper.
 use self::Inner::*;
 use super::{
     child_buffer::ChildBuffer,

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -157,9 +157,11 @@ impl<N: StaticSize + HasStoragePreference> Node<N> {
     pub(super) fn try_find_flush_candidate(&mut self) -> Option<TakeChildBuffer<ChildBuffer<N>>> {
         match self.0 {
             Leaf(_) | PackedLeaf(_) => None,
-            Internal(ref mut internal) => {
-                internal.try_find_flush_candidate(MIN_FLUSH_SIZE, MAX_INTERNAL_NODE_SIZE, MIN_FANOUT)
-            }
+            Internal(ref mut internal) => internal.try_find_flush_candidate(
+                MIN_FLUSH_SIZE,
+                MAX_INTERNAL_NODE_SIZE,
+                MIN_FANOUT,
+            ),
         }
     }
 

--- a/betree/src/tree/imp/packed.rs
+++ b/betree/src/tree/imp/packed.rs
@@ -68,7 +68,7 @@ fn prefix_size(entry_count: u32) -> usize {
 
 impl PackedMap {
     pub fn new(data: Vec<u8>) -> Self {
-        assert!(data.len() >= 4);
+        debug_assert!(data.len() >= 4);
         let entry_count = LittleEndian::read_u32(&data[..4]);
         let system_preference = data[4];
 
@@ -88,7 +88,7 @@ impl PackedMap {
     // In the data segment, the value is always written directly after the key,
     // so the key length can be calculated by subtraction.
     fn key_pos(&self, idx: u32) -> (Offset, u32) {
-        assert!(idx < self.entry_count);
+        debug_assert!(idx < self.entry_count);
 
         let entry_pos = HEADER_LEN + idx as usize * ENTRY_LEN;
 
@@ -102,7 +102,7 @@ impl PackedMap {
     // In the data segment, the next key is usually written after the current value,
     // so the value length can usually be calculated by subtraction.
     fn val_pos(&self, idx: u32) -> (Offset, u32) {
-        assert!(idx < self.entry_count);
+        debug_assert!(idx < self.entry_count);
 
         let entry_pos = HEADER_LEN + idx as usize * ENTRY_LEN;
         let data_offset = self.read_offset(entry_pos + ENTRY_DATA_OFFSET);

--- a/betree/src/tree/imp/packed.rs
+++ b/betree/src/tree/imp/packed.rs
@@ -29,7 +29,6 @@ pub(crate) const ENTRY_KEY_OFFSET: usize = 0;
 pub(crate) const ENTRY_KEY_INFO_OFFSET: usize = ENTRY_KEY_OFFSET + OFFSET_LEN;
 pub(crate) const ENTRY_DATA_OFFSET: usize = ENTRY_KEY_INFO_OFFSET + 1;
 
-
 /// On-disk serialized leaf node. Simplified to a map contains 40 bytes of
 /// headers followed by data.
 ///

--- a/betree/src/tree/imp/packed.rs
+++ b/betree/src/tree/imp/packed.rs
@@ -1,3 +1,6 @@
+//! On-disk representation of a node.
+//!
+//! Can be used for read-only access to avoid deserialization.
 use super::leaf::LeafNode;
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
@@ -26,6 +29,10 @@ pub(crate) const ENTRY_KEY_OFFSET: usize = 0;
 pub(crate) const ENTRY_KEY_INFO_OFFSET: usize = ENTRY_KEY_OFFSET + OFFSET_LEN;
 pub(crate) const ENTRY_DATA_OFFSET: usize = ENTRY_KEY_INFO_OFFSET + 1;
 
+
+/// On-disk serialized leaf node. Simplified to a map contains 40 bytes of
+/// headers followed by data.
+///
 /// ```text
 /// Layout:
 ///     entry_count: u32,
@@ -53,12 +60,13 @@ pub(crate) const ENTRY_DATA_OFFSET: usize = ENTRY_KEY_INFO_OFFSET + 1;
 ///
 /// ```
 #[derive(Debug)]
-pub struct PackedMap {
+pub(crate) struct PackedMap {
     entry_count: u32,
     system_preference: u8,
     data: CowBytes,
 }
 
+/// New type for safe-handling of data offsets u32s.
 #[derive(Debug, Copy, Clone)]
 struct Offset(u32);
 

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -132,7 +132,7 @@ where
             }
             next_pivot
                 .as_ref()
-                .map(|pivot| self.finished = &pivot[..] >= max_key);
+                .map(|pivot| self.finished = &pivot[..] >= &max_key[..]);
         }
 
         match next_pivot {

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -125,17 +125,15 @@ where
             {
                 self.buffer.pop_back().unwrap();
             }
+            next_pivot.as_ref().map(|pivot| {
+                self.finished = &pivot[..] >= max_key
+            });
         }
 
         match next_pivot {
-            // If the pivot key is equal or greater to our max key then this was
-            // the last leaf that contains data for this range query.
-            Some(pivot) if self.max_key.as_ref().map(|mk| &pivot[..] >= &mk[..]) == Some(true) => {
-                self.finished = true;
-            }
-            // Otherwise we will update our min key for the next fill_buffer
-            // call.
-            Some(pivot) => {
+            // If we have not encountered any entry larger than max key, we will
+            // update our min key for the next fill_buffer call.
+            Some(pivot) if !self.finished => {
                 let mut last_key = pivot.to_vec();
                 // `last_key` is actually exact.
                 // There are no values on this path we have not seen.
@@ -147,6 +145,7 @@ where
             None => {
                 self.finished = true;
             }
+            _ => {}
         }
 
         Ok(())

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, HasStoragePreference, ObjectRef},
-    tree::{errors::*, KeyInfo, MessageAction},
+    tree::{errors::*, KeyInfo, MessageAction, Value, Key},
 };
 use std::{
     borrow::Borrow,
@@ -26,7 +26,7 @@ enum Bounded<T> {
 
 /// The range iterator of a tree.
 pub struct RangeIterator<X: Dml, M, I: Borrow<Inner<X::ObjectRef, X::Info, M>>> {
-    buffer: VecDeque<(CowBytes, (KeyInfo, SlicedCowBytes))>,
+    buffer: VecDeque<(Key, (KeyInfo, Value))>,
     min_key: Bounded<Vec<u8>>,
     /// Always inclusive
     max_key: Option<Vec<u8>>,
@@ -42,7 +42,7 @@ where
     M: MessageAction,
     I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
 {
-    type Item = Result<(CowBytes, SlicedCowBytes), Error>;
+    type Item = Result<(Key, Value), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, HasStoragePreference, ObjectRef},
-    tree::{errors::*, KeyInfo, MessageAction, Value, Key},
+    tree::{errors::*, Key, KeyInfo, MessageAction, Value},
 };
 use std::{
     borrow::Borrow,
@@ -130,9 +130,9 @@ where
             {
                 self.buffer.pop_back().unwrap();
             }
-            next_pivot.as_ref().map(|pivot| {
-                self.finished = &pivot[..] >= max_key
-            });
+            next_pivot
+                .as_ref()
+                .map(|pivot| self.finished = &pivot[..] >= max_key);
         }
 
         match next_pivot {

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -24,7 +24,11 @@ enum Bounded<T> {
     Excluded(T),
 }
 
-/// The range iterator of a tree.
+/// The range iterator over (key,value)-tuples of a tree.
+///
+/// The iterator performs asynchronous prefetching to allow for a better
+/// utilization of underlying resources. It is advised to use [RangeIterator]
+/// and methods utilizing it in almost all cases.
 pub struct RangeIterator<X: Dml, M, I: Borrow<Inner<X::ObjectRef, X::Info, M>>> {
     buffer: VecDeque<(Key, (KeyInfo, Value))>,
     min_key: Bounded<Vec<u8>>,

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -1,3 +1,4 @@
+//! Iterator over a range of keys in a [Tree].
 use super::{
     node::{GetRangeResult, Node},
     Inner, Tree,

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -47,7 +47,7 @@ where
     M: MessageAction,
     I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
 {
-    type Item = Result<(Key, Value), Error>;
+    type Item = Result<(Key, Value), TreeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -100,7 +100,7 @@ where
         }
     }
 
-    fn fill_buffer(&mut self) -> Result<(), Error> {
+    fn fill_buffer(&mut self) -> Result<(), TreeError> {
         let next_pivot = {
             let min_key = match self.min_key {
                 Bounded::Included(ref x) | Bounded::Excluded(ref x) => x,
@@ -169,7 +169,7 @@ where
         key: &[u8],
         data: &mut VecDeque<(CowBytes, (KeyInfo, SlicedCowBytes))>,
         prefetch: &mut Option<X::Prefetch>,
-    ) -> Result<Option<CowBytes>, Error> {
+    ) -> Result<Option<CowBytes>, TreeError> {
         let result = {
             let mut left_pivot_key = None;
             let mut right_pivot_key = None;

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -238,7 +238,6 @@ where
                 None => true,
                 Some(ref max_key) => key <= max_key,
             });
-        // TODO
         let leaf_entries = leaf_entries.map(|(k, v)| (CowBytes::from(k), v));
 
         for (key, msgs, value) in MergeByKeyIterator::new(msgs_iter, leaf_entries) {

--- a/betree/src/tree/imp/split.rs
+++ b/betree/src/tree/imp/split.rs
@@ -45,7 +45,7 @@ where
         &self,
         mut node: X::CacheValueRefMut,
         parent: &mut TakeChildBuffer<ChildBuffer<R>>,
-    ) -> Result<(X::CacheValueRefMut, isize), Error> {
+    ) -> Result<(X::CacheValueRefMut, isize), TreeError> {
         self.dml.verify_cache();
 
         let before = node.size();

--- a/betree/src/tree/imp/split.rs
+++ b/betree/src/tree/imp/split.rs
@@ -1,3 +1,4 @@
+//! Encapsulating logic for splitting of normal and root nodes.
 use super::{child_buffer::ChildBuffer, internal::TakeChildBuffer, Inner, Node, Tree};
 use crate::{
     cache::AddSize,

--- a/betree/src/tree/imp/split.rs
+++ b/betree/src/tree/imp/split.rs
@@ -17,7 +17,7 @@ where
     pub(super) fn split_root_node(&self, mut root_node: X::CacheValueRefMut) {
         self.dml.verify_cache();
         let before = root_node.size();
-        info!(
+        debug!(
             "Splitting root. {}, {:?}, {}, {:?}",
             root_node.kind(),
             root_node.fanout(),
@@ -25,7 +25,7 @@ where
             root_node.actual_size()
         );
         let size_delta = root_node.split_root_mut(|node| {
-            info!(
+            debug!(
                 "Root split child: {}, {:?}, {}, {:?}",
                 node.kind(),
                 node.fanout(),
@@ -35,7 +35,7 @@ where
             self.dml.insert(node, self.tree_id())
         });
         info!("Root split done. {}, {}", root_node.size(), size_delta);
-        assert!(before as isize + size_delta == root_node.size() as isize);
+        debug_assert!(before as isize + size_delta == root_node.size() as isize);
         root_node.finish(size_delta);
         self.dml.verify_cache();
     }
@@ -50,7 +50,7 @@ where
         let before = node.size();
         let (sibling, pivot_key, size_delta) = node.split();
         let select_right = sibling.size() > node.size();
-        info!(
+        debug!(
             "split {}: {} -> ({}, {}), {}",
             node.kind(),
             before,

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -34,8 +34,16 @@ pub trait TreeBaseLayer<M: MessageAction> {
 pub trait TreeLayer<M: MessageAction>: TreeBaseLayer<M> {
     /// The range query iterator.
     type Range: Iterator<Item = Result<(Key, Value), Error>>;
-    /// Issues a range query for the given key `range`.
-    /// Returns an iterator that will iterate over the entries in that range.
+    /// Issues a range query for the given key range.
+    /// Returns an iterator over (key, value)-tuples in that range.
+    ///
+    /// ```rust,ignore
+    /// let a = [1,2,3];
+    /// let b = [2,3,4];
+    /// for (key, value) in my_tree.range(a..b) {
+    ///     todo!()
+    /// }
+    /// ```
     fn range<K, R>(&self, range: R) -> Result<Self::Range, Error>
     where
         R: RangeBounds<K>,

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -22,19 +22,19 @@ pub trait TreeBaseLayer<M: MessageAction> {
         key: K,
         msg: SlicedCowBytes,
         storage_preference: StoragePreference,
-    ) -> Result<(), Error>;
+    ) -> Result<(), TreeError>;
 
     /// Gets the entry for the given `key` if it exists.
-    fn get<K: Borrow<[u8]>>(&self, key: K) -> Result<Option<SlicedCowBytes>, Error>;
+    fn get<K: Borrow<[u8]>>(&self, key: K) -> Result<Option<SlicedCowBytes>, TreeError>;
 
     /// Returns the depth of the tree.
-    fn depth(&self) -> Result<u32, Error>;
+    fn depth(&self) -> Result<u32, TreeError>;
 }
 
 /// Tree Layer interface.
 pub trait TreeLayer<M: MessageAction>: TreeBaseLayer<M> {
     /// The range query iterator.
-    type Range: Iterator<Item = Result<(Key, Value), Error>>;
+    type Range: Iterator<Item = Result<(Key, Value), TreeError>>;
     /// Issues a range query for the given key range.
     /// Returns an iterator over (key, value)-tuples in that range.
     ///
@@ -45,7 +45,7 @@ pub trait TreeLayer<M: MessageAction>: TreeBaseLayer<M> {
     ///     todo!()
     /// }
     /// ```
-    fn range<K, R>(&self, range: R) -> Result<Self::Range, Error>
+    fn range<K, R>(&self, range: R) -> Result<Self::Range, TreeError>
     where
         R: RangeBounds<K>,
         K: Borrow<[u8]> + Into<CowBytes>,
@@ -55,14 +55,14 @@ pub trait TreeLayer<M: MessageAction>: TreeBaseLayer<M> {
     type Pointer: Serialize + DeserializeOwned;
 
     /// Sync the tree to disk.
-    fn sync(&self) -> Result<Self::Pointer, Error>;
+    fn sync(&self) -> Result<Self::Pointer, TreeError>;
 }
 
 /// Special-purpose interface to allow for storing and syncing trees of different message types.
 pub(crate) trait ErasedTreeSync {
     type Pointer;
     type ObjectRef;
-    fn erased_sync(&self) -> Result<Self::Pointer, Error>;
+    fn erased_sync(&self) -> Result<Self::Pointer, TreeError>;
     // ObjectRef is not object-safe, but we only need the lock, not the value
     // FIXME: find an actual abstraction, instead of encoding implementation details into this trait
     fn erased_try_lock_root(

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -1,3 +1,4 @@
+//! Interface traits for the tree layer of *Haura*.
 use super::{MessageAction, Key, Value};
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -1,4 +1,4 @@
-use super::MessageAction;
+use super::{MessageAction, Key, Value};
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     StoragePreference,
@@ -33,7 +33,7 @@ pub trait TreeBaseLayer<M: MessageAction> {
 /// Tree Layer interface.
 pub trait TreeLayer<M: MessageAction>: TreeBaseLayer<M> {
     /// The range query iterator.
-    type Range: Iterator<Item = Result<(CowBytes, SlicedCowBytes), Error>>;
+    type Range: Iterator<Item = Result<(Key, Value), Error>>;
     /// Issues a range query for the given key `range`.
     /// Returns an iterator that will iterate over the entries in that range.
     fn range<K, R>(&self, range: R) -> Result<Self::Range, Error>

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -1,5 +1,5 @@
 //! Interface traits for the tree layer of *Haura*.
-use super::{MessageAction, Key, Value};
+use super::{Key, MessageAction, Value};
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     StoragePreference,

--- a/betree/src/tree/layer.rs
+++ b/betree/src/tree/layer.rs
@@ -10,9 +10,8 @@ use std::{borrow::Borrow, ops::RangeBounds};
 
 use super::errors::*;
 
-// TODO
-// - ro transaction
-// - how to do range delete with ro transaction?
+// TODO:
+// 1. Read-only transactions (We could lessen some restrictions about exclusivity)
 
 /// Basic Tree Layer interface.
 pub trait TreeBaseLayer<M: MessageAction> {

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -9,7 +9,7 @@ mod message_action;
 
 use crate::cow_bytes::{CowBytes, SlicedCowBytes};
 
-pub use self::{
+pub(crate) use self::{
     default_message_action::DefaultMessageAction,
     errors::{Error, ErrorKind},
     imp::{Inner, Node, RangeIterator, Tree},

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -16,9 +16,7 @@ pub(crate) use self::{
     message_action::MessageAction,
 };
 
-pub use self::{
-    errors::TreeError,
-};
+pub use self::errors::TreeError;
 
 type Key = CowBytes;
 type Value = SlicedCowBytes;

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -7,6 +7,8 @@ mod imp;
 mod layer;
 mod message_action;
 
+use crate::cow_bytes::{CowBytes, SlicedCowBytes};
+
 pub use self::{
     default_message_action::DefaultMessageAction,
     errors::{Error, ErrorKind},
@@ -15,5 +17,8 @@ pub use self::{
     message_action::MessageAction,
 };
 
-pub(in crate::tree) use self::imp::KeyInfo;
+type Key = CowBytes;
+type Value = SlicedCowBytes;
+
+use self::imp::KeyInfo;
 pub(crate) use self::{imp::MAX_MESSAGE_SIZE, layer::ErasedTreeSync};

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -11,10 +11,13 @@ use crate::cow_bytes::{CowBytes, SlicedCowBytes};
 
 pub(crate) use self::{
     default_message_action::DefaultMessageAction,
-    errors::{Error, ErrorKind},
     imp::{Inner, Node, RangeIterator, Tree},
     layer::{TreeBaseLayer, TreeLayer},
     message_action::MessageAction,
+};
+
+pub use self::{
+    errors::TreeError,
 };
 
 type Key = CowBytes;

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -9,7 +9,7 @@ mod message_action;
 
 use crate::cow_bytes::{CowBytes, SlicedCowBytes};
 
-pub(crate) use self::{
+pub use self::{
     default_message_action::DefaultMessageAction,
     imp::{Inner, Node, RangeIterator, Tree},
     layer::{TreeBaseLayer, TreeLayer},


### PR DESCRIPTION
This PR contains some refactoring and reworking of the `tree` module. 

It largely aims to clean unclear paths and functions which were not documented. These changes are also used as the basis to a more general rework of the trait-to-structure design of *Haura* (They can be found under #32).

With the rework we also close some long open TODOs and FIXMEs, as well as clearing the pathways for node identification/access which we want to have for more fine grained accesses.

Summary:
- Fix & Document Tree Rebalancing Operations
- Copy Preferences on node split, if system preference is set
- Run internally-relevant asserts only in debug
- Extend Documentation & Visibility of the module
- Mitigate magic number use
- Extract general purpose impls into separate submodule
- Fix size updates when splitting/merging nodes
- Evict empty nodes early
