### PR TITLE
Object: Expose Id handling with "internal-api" feature & Add Named Store Iterator

### DIFF
--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -251,8 +251,14 @@ impl<Config: DatabaseBuilder + Clone> Database<Config> {
         )
     }
 
+    /// Creates an iterator over all object stores by their internally used Id.
+    #[cfg(feature = "internal-api")]
+    pub fn iter_object_stores_pub(&self) -> Result<impl Iterator<Item = Result<ObjectStoreId>>> {
+        self.iter_object_stores()
+    }
+
     /// Iterates over all object stores in the database.
-    pub fn iter_object_stores(&self) -> Result<impl Iterator<Item = Result<ObjectStoreId>>> {
+    pub(crate) fn iter_object_stores(&self) -> Result<impl Iterator<Item = Result<ObjectStoreId>>> {
         let low = &[OBJECT_STORE_DATA_PREFIX] as &[_];
         let high = &[OBJECT_STORE_DATA_PREFIX + 1] as &[_];
         Ok(self.root_tree.range(low..high)?.map(move |result| {

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -267,6 +267,20 @@ impl<Config: DatabaseBuilder + Clone> Database<Config> {
         }))
     }
 
+    /// Iterates over all object stores by their given names.
+    pub fn iter_object_store_names(&self) -> Result<impl Iterator<Item = CowBytes>> {
+        let low = &[OBJECT_STORE_NAME_TO_ID_PREFIX] as &[_];
+        let high = &[OBJECT_STORE_NAME_TO_ID_PREFIX + 1] as &[_];
+        Ok(self.root_tree.range(low..high)?.filter_map(move |result| {
+            result.ok().and_then(|(b, _)| {
+                match b.contains(&0) {
+                    true => None,
+                    false => Some(b)
+                }
+            })
+        }))
+    }
+
     /// Create an object store backed by a single database.
     pub fn open_object_store(&mut self) -> Result<ObjectStore<Config>> {
         let id = self.get_or_create_os_id(&[0])?;

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -225,6 +225,14 @@ impl<Config: DatabaseBuilder + Clone> Database<Config> {
     /// Open an object store by its internal Id. This method can be used
     /// whenever storing the actual names of object stores is too much expected
     /// effort.
+    #[cfg(feature = "internal-api")]
+    pub fn open_object_store_with_id_pub(
+        &mut self,
+        os_id: ObjectStoreId,
+    ) -> Result<ObjectStore<Config>> {
+        self.open_object_store_with_id(os_id)
+    }
+
     pub(crate) fn open_object_store_with_id(
         &mut self,
         os_id: ObjectStoreId,

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -65,10 +65,18 @@ fn object_store_object_iter() {
 }
 
 #[test]
-fn object_store_reinit_from_id() {
-        let mut db = test_db(2, 64);
-        let os = db.open_object_store().unwrap();
-        db.close_object_store(os);
-        let mut osl = db.iter_object_stores().unwrap();
-        let _ = db.open_object_store_with_id(osl.next().unwrap().unwrap()).unwrap();
+fn object_store_reinit_from_iterator() {
+    // Test opening of multiple stores by their names.
+    // Test if the default store name '0' gets skipped.
+    let mut db = test_db(2, 64);
+    let os = db.open_named_object_store(b"foo", StoragePreference::NONE).unwrap();
+    db.close_object_store(os);
+    let os = db.open_named_object_store(b"bar", StoragePreference::NONE).unwrap();
+    db.close_object_store(os);
+    let os = db.open_object_store().unwrap();
+    db.close_object_store(os);
+    assert!(db.iter_object_store_names().unwrap().count() == 2);
+    for name in db.iter_object_store_names().unwrap() {
+        let _ = db.open_named_object_store(&name, StoragePreference::NONE).unwrap();
+    }
 }

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -47,7 +47,7 @@ fn object_store_iter() {
         db.close_object_store(os);
         let os = db.open_named_object_store(b"snek", StoragePreference::NONE).unwrap();
         db.close_object_store(os);
-        let mut osl = db.iter_object_stores().unwrap();
+        let mut osl = db.iter_object_stores_pub().unwrap();
         assert_eq!(osl.next().unwrap().unwrap().as_u64(), 1);
         assert_eq!(osl.next().unwrap().unwrap().as_u64(), 2);
         assert_eq!(osl.next().unwrap().unwrap().as_u64(), 3);


### PR DESCRIPTION
This PR partially modifies the public interface of the object store and allows some more internals to be tested with the "internal-api" feature. Mainly, we expose the iterator over object store ids to tests via the "internal-api" feature flag, to allow for init code testing as we perform when opening a database from storage.

Further, this PR adds a similar function to any user with `iter_object_store_names` which returns an iterator over all names of already created object stores. This can be handy when multiple stores are opened automatically for use-case with countless arbitrary stores such as per external-user or per application object stores.