### PR TITLE
workflows: Improve CI and Pages workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 jobs:
   dependencies:
     name: Dependencies
@@ -18,9 +12,9 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: |
+          rm --recursive --force "${HOME}/.cargo" "${HOME}/.rustup"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "${HOME}/.cargo/env"
-          rustup toolchain install stable --profile minimal --force
           echo "RUSTC_VERSION=$(rustc --version | grep --only-matching '[0-9]\+\.[0-9]\+\.[0-9]\+' | head --lines=1)" >> $GITHUB_ENV
       - name: Cache dependencies
         id: cache
@@ -56,9 +50,9 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: |
+          rm --recursive --force "${HOME}/.cargo" "${HOME}/.rustup"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "${HOME}/.cargo/env"
-          rustup toolchain install stable --profile minimal --force
           echo "RUSTC_VERSION=$(rustc --version | grep --only-matching '[0-9]\+\.[0-9]\+\.[0-9]\+' | head --lines=1)" >> $GITHUB_ENV
       - name: Cache dependencies
         id: cache
@@ -94,9 +88,9 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: |
+          rm --recursive --force "${HOME}/.cargo" "${HOME}/.rustup"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "${HOME}/.cargo/env"
-          rustup toolchain install stable --profile minimal --force
           echo "RUSTC_VERSION=$(rustc --version | grep --only-matching '[0-9]\+\.[0-9]\+\.[0-9]\+' | head --lines=1)" >> $GITHUB_ENV
       - name: Cache dependencies
         id: cache
@@ -129,41 +123,38 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: |
+          rm --recursive --force "${HOME}/.cargo" "${HOME}/.rustup"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . "${HOME}/.cargo/env"
-          rustup toolchain install stable --profile minimal --force
-      - name: Cargo MSRV Cache
+          echo "RUSTC_VERSION=$(rustc --version | grep --only-matching '[0-9]\+\.[0-9]\+\.[0-9]\+' | head --lines=1)" >> $GITHUB_ENV
+      - name: Cache MSRV
         id: cache
         uses: actions/cache@v3
+        # Environment variables do not seem to work, use ~ instead.
         with:
           path: |
             ~/.cargo
-            ~/julea
-          # This is only supposed to cache the cargo-msrv binary, for this the
-          # rust version and other infos are irrelevant.
-          key: ubuntu-22.04-rustc
+          key: ubuntu-22.04-rustc-${{ env.RUSTC_VERSION }}-msrv
       - name: Prepare JULEA
         run: |
-          sudo apt update
-          sudo apt install libglib2.0-0 libglib2.0-dev libbson-1.0-0 libbson-dev clang make pkg-config
-          # use forked version
-          cd ~
-          git clone -b modules-conditional-unload https://github.com/tilpner/julea.git
-      - name: Install cargo-msrv
+          sudo apt update || true
+          sudo apt --yes --no-install-recommends install pkgconf libglib2.0-dev libbson-dev
+          # FIXME use forked version
+          git clone --depth 1 --branch modules-conditional-unload https://github.com/tilpner/julea.git "${HOME}/julea"
+      - name: Install MSRV
         run: |
-          # Will skip compilation if already present
           cargo install cargo-msrv
-      - name: Verify betree MSRV
+      - name: Verify betree
         run: |
           cd betree
           cargo msrv verify
-      - name: Verify bectl MSRV
+      - name: Verify bectl
         run: |
           cd bectl
           cargo msrv verify
-      - name: Verify julea-betree MSRV
+      - name: Verify julea-betree
         run: |
           cd julea-betree
-          export JULEA_INCLUDE=~/julea/include
+          export JULEA_INCLUDE="${HOME}/julea/include"
           export BINDGEN_EXTRA_CLANG_ARGS="$(pkg-config --cflags glib-2.0) $(pkg-config --cflags libbson-1.0)"
           cargo msrv verify

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,65 +1,64 @@
-name: pages-haura-getting-started
-
-on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
+name: Pages
+on: [push, pull_request]
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  mdbook:
+    name: mdBook
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Configure Pages
-      uses: actions/configure-pages@v2
-    - name: Binary Cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          bin
-        key: ${{ runner.os }}-cargo-mdbook
-    - name: Install mdbook
-      run: |
-        mkdir bin
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
-        curl -sSL https://github.com/dylanowen/mdbook-graphviz/releases/download/v0.1.5/mdbook-graphviz_v0.1.5_x86_64-unknown-linux-musl.zip > mdviz.zip
-        unzip mdviz.zip -d bin
-    - name: Install graphviz
-      run: |
-        sudo apt update
-        sudo apt install -y graphviz
-    - name: Build book
-      run: |
-        PATH=$PATH:$PWD/bin
-        cd docs
-        ../bin/mdbook build
-    - name: Upload Book Artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: ./docs/book
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: |
+          rm --recursive --force "${HOME}/.cargo" "${HOME}/.rustup"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "${HOME}/.cargo/env"
+          echo "RUSTC_VERSION=$(rustc --version | grep --only-matching '[0-9]\+\.[0-9]\+\.[0-9]\+' | head --lines=1)" >> $GITHUB_ENV
+      - name: Install Graphviz
+        run: |
+          sudo apt update || true
+          sudo apt --yes --no-install-recommends install graphviz
+      - name: Cache mdBook
+        id: cache
+        uses: actions/cache@v3
+        # Environment variables do not seem to work, use ~ instead.
+        with:
+          path: |
+            ~/.cargo
+          key: ubuntu-22.04-rustc-${{ env.RUSTC_VERSION }}-mdbook
+      - name: Install mdBook
+        run: |
+          cargo install mdbook
+          cargo install mdbook-graphviz
+      - name: Configure Pages
+        uses: actions/configure-pages@v2
+      - name: Build book
+        run: |
+          cd docs
+          mdbook build
+      - name: Upload book
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/book
   deploy:
-    runs-on: ubuntu-latest
-    needs: build
+    name: Deploy
+    needs: mdbook
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Deploy Pages
-      id: deployment
-      uses: actions/deploy-pages@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Be-Tree Storage Stack
 
 [![CI](https://github.com/julea-io/haura/workflows/CI/badge.svg)](https://github.com/julea-io/haura/actions)
+[![Pages](https://github.com/julea-io/haura/workflows/Pages/badge.svg)](https://github.com/julea-io/haura/actions)
 
 A storage library offering key-value and object interfaces by managing B^ε-trees on block storage devices.
 


### PR DESCRIPTION
The CI workflow currently reuses some Rust components present in the builder images. Clean them up properly before installing current Rust. It also fails if JULEA has been cached already, therefore do not include JULEA in the cache.

The Pages workflow currently fails if a cache exists already. Fix this and install mdBook using Cargo instead.