### PR TITLE
tree: Add Pivot Key

### DIFF
--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -55,7 +55,8 @@ bitvec = "1.0"
 
 serde_json = "1.0"
 crossbeam-channel = "0.5.5"
-lfu_cache = { git = "https://github.com/julea-io/lfu-cache", rev = "haura-v4" }
+# FIXME: THIS IS NOT MEANT FOR THE FINAL PR REMOVE BEFORE, DO NOT DEPEND ON UNPINNED VERSIONS
+lfu_cache = { git = "https://github.com/julea-io/lfu-cache", branch = "rework" }
 rand = { version = "0.8", features = ["std_rng"] }
 
 [dev-dependencies]

--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -55,8 +55,7 @@ bitvec = "1.0"
 
 serde_json = "1.0"
 crossbeam-channel = "0.5.5"
-# FIXME: THIS IS NOT MEANT FOR THE FINAL PR REMOVE BEFORE, DO NOT DEPEND ON UNPINNED VERSIONS
-lfu_cache = { git = "https://github.com/julea-io/lfu-cache", branch = "rework" }
+lfu_cache = { git = "https://github.com/julea-io/lfu-cache", rev = "haura-v5" }
 rand = { version = "0.8", features = ["std_rng"] }
 
 [dev-dependencies]

--- a/betree/src/cow_bytes.rs
+++ b/betree/src/cow_bytes.rs
@@ -13,7 +13,7 @@ use std::{
 
 /// Copy-on-Write smart pointer which supports cheap cloning as it is
 /// reference-counted.
-#[derive(Debug, Clone, Eq, Ord, Default)]
+#[derive(Hash, Debug, Clone, Eq, Ord, Default)]
 pub struct CowBytes {
     // TODO Replace by own implementation
     pub(super) inner: Arc<Vec<u8>>,

--- a/betree/src/data_management/cache_value.rs
+++ b/betree/src/data_management/cache_value.rs
@@ -1,6 +1,4 @@
-use crate::{
-    cache::AddSize, size::SizeMut
-};
+use crate::{cache::AddSize, size::SizeMut};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use stable_deref_trait::StableDeref;
 use std::{
@@ -84,10 +82,7 @@ pub struct TaggedCacheValue<Val, Tag> {
 
 impl<Val, Tag> TaggedCacheValue<Val, Tag> {
     pub fn new(value: Val, tag: Tag) -> Self {
-        Self {
-            value,
-            tag,
-        }
+        Self { value, tag }
     }
 
     pub fn value(&self) -> &Val {

--- a/betree/src/data_management/cache_value.rs
+++ b/betree/src/data_management/cache_value.rs
@@ -1,0 +1,120 @@
+use crate::{
+    cache::AddSize, size::SizeMut
+};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use stable_deref_trait::StableDeref;
+use std::{
+    mem::{transmute, ManuallyDrop},
+    ops::{Deref, DerefMut},
+};
+
+pub struct CacheValueRef<T, U> {
+    head: T,
+    guard: ManuallyDrop<U>,
+}
+
+impl<T, U> Drop for CacheValueRef<T, U> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.guard);
+        }
+    }
+}
+
+impl<T: AddSize, U> AddSize for CacheValueRef<T, U> {
+    fn add_size(&self, size_delta: isize) {
+        self.head.add_size(size_delta)
+    }
+}
+
+impl<T, U, I> CacheValueRef<T, RwLockReadGuard<'static, U>>
+where
+    T: StableDeref<Target = TaggedCacheValue<RwLock<U>, I>>,
+{
+    pub(super) fn read(head: T) -> Self {
+        let guard = unsafe { transmute(RwLock::read(&head.value)) };
+        CacheValueRef {
+            head,
+            guard: ManuallyDrop::new(guard),
+        }
+    }
+}
+
+impl<T, U, I> CacheValueRef<T, RwLockWriteGuard<'static, U>>
+where
+    T: StableDeref<Target = TaggedCacheValue<RwLock<U>, I>>,
+{
+    pub(super) fn write(head: T) -> Self {
+        let guard = unsafe { transmute(RwLock::write(&head.value)) };
+        CacheValueRef {
+            head,
+            guard: ManuallyDrop::new(guard),
+        }
+    }
+}
+
+unsafe impl<T, U> StableDeref for CacheValueRef<T, RwLockReadGuard<'static, U>> {}
+
+impl<T, U> Deref for CacheValueRef<T, RwLockReadGuard<'static, U>> {
+    type Target = U;
+    fn deref(&self) -> &U {
+        &self.guard
+    }
+}
+
+unsafe impl<T, U> StableDeref for CacheValueRef<T, RwLockWriteGuard<'static, U>> {}
+
+impl<T, U> Deref for CacheValueRef<T, RwLockWriteGuard<'static, U>> {
+    type Target = U;
+    fn deref(&self) -> &U {
+        &self.guard
+    }
+}
+
+impl<T, U> DerefMut for CacheValueRef<T, RwLockWriteGuard<'static, U>> {
+    fn deref_mut(&mut self) -> &mut U {
+        &mut self.guard
+    }
+}
+
+pub struct TaggedCacheValue<Val, Tag> {
+    value: Val,
+    tag: Tag,
+}
+
+impl<Val, Tag> TaggedCacheValue<Val, Tag> {
+    pub fn new(value: Val, tag: Tag) -> Self {
+        Self {
+            value,
+            tag,
+        }
+    }
+
+    pub fn value(&self) -> &Val {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut Val {
+        &mut self.value
+    }
+
+    pub fn into_value(self) -> Val {
+        self.value
+    }
+
+    pub fn tag(&self) -> &Tag {
+        &self.tag
+    }
+}
+
+impl<Val: AddSize, Tag> AddSize for TaggedCacheValue<Val, Tag> {
+    fn add_size(&self, size_delta: isize) {
+        self.value.add_size(size_delta)
+    }
+}
+
+impl<Val: SizeMut, Tag> SizeMut for TaggedCacheValue<Val, Tag> {
+    fn size(&mut self) -> usize {
+        self.value.size()
+    }
+}

--- a/betree/src/data_management/delegation.rs
+++ b/betree/src/data_management/delegation.rs
@@ -1,4 +1,4 @@
-use crate::{tree::PivotKey, database::DatasetId};
+use crate::{database::DatasetId, tree::PivotKey};
 
 use super::{Dml, Error};
 use std::ops::{Deref, DerefMut};

--- a/betree/src/data_management/delegation.rs
+++ b/betree/src/data_management/delegation.rs
@@ -69,8 +69,8 @@ where
         (**self).verify_cache()
     }
 
-    fn ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef {
-        <T::Target as Dml>::ref_from_ptr(r)
+    fn root_ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef {
+        <T::Target as Dml>::root_ref_from_ptr(r)
     }
 
     fn write_back<F, G>(&self, acquire_or_lock: F) -> Result<Self::ObjectPointer, Error>

--- a/betree/src/data_management/delegation.rs
+++ b/betree/src/data_management/delegation.rs
@@ -1,3 +1,5 @@
+use crate::{tree::PivotKey, database::DatasetId};
+
 use super::{Dml, Error};
 use std::ops::{Deref, DerefMut};
 
@@ -8,7 +10,6 @@ where
 {
     type ObjectRef = <T::Target as Dml>::ObjectRef;
     type ObjectPointer = <T::Target as Dml>::ObjectPointer;
-    type Info = <T::Target as Dml>::Info;
     type Object = <T::Target as Dml>::Object;
     type CacheValueRef = <T::Target as Dml>::CacheValueRef;
     type CacheValueRefMut = <T::Target as Dml>::CacheValueRefMut;
@@ -30,7 +31,7 @@ where
     fn get_mut(
         &self,
         or: &mut Self::ObjectRef,
-        info: Self::Info,
+        info: DatasetId,
     ) -> Result<Self::CacheValueRefMut, Error> {
         (**self).get_mut(or, info)
     }
@@ -39,16 +40,17 @@ where
         (**self).try_get_mut(or)
     }
 
-    fn insert(&self, object: Self::Object, info: Self::Info) -> Self::ObjectRef {
-        (**self).insert(object, info)
+    fn insert(&self, object: Self::Object, info: DatasetId, pk: PivotKey) -> Self::ObjectRef {
+        (**self).insert(object, info, pk)
     }
 
     fn insert_and_get_mut(
         &self,
         object: Self::Object,
-        info: Self::Info,
+        info: DatasetId,
+        pk: PivotKey,
     ) -> (Self::CacheValueRefMut, Self::ObjectRef) {
-        (**self).insert_and_get_mut(object, info)
+        (**self).insert_and_get_mut(object, info, pk)
     }
 
     fn remove(&self, or: Self::ObjectRef) {

--- a/betree/src/data_management/dmu.rs
+++ b/betree/src/data_management/dmu.rs
@@ -1,6 +1,7 @@
 use super::{
     errors::*,
-    impls::{CacheValueRef, ModifiedObjectId, ObjRef, ObjectKey, TaggedCacheValue},
+    cache_value::{CacheValueRef, TaggedCacheValue},
+    impls::{ModifiedObjectId, ObjRef, ObjectKey},
     object_ptr::ObjectPointer,
     CopyOnWriteEvent, Dml, HasStoragePreference, Object, ObjectReference,
 };

--- a/betree/src/data_management/dmu.rs
+++ b/betree/src/data_management/dmu.rs
@@ -583,11 +583,7 @@ where
 
     /// Tries to allocate `size` blocks at `disk_offset`.  Might fail if
     /// already in use.
-    pub fn allocate_raw_at(
-        &self,
-        disk_offset: DiskOffset,
-        size: Block<u32>,
-    ) -> Result<(), Error> {
+    pub fn allocate_raw_at(&self, disk_offset: DiskOffset, size: Block<u32>) -> Result<(), Error> {
         let disk_id = disk_offset.disk_id();
         let num_disks = self.pool.num_disks(disk_offset.storage_class(), disk_id);
         let size = size * num_disks as u32;

--- a/betree/src/data_management/dmu.rs
+++ b/betree/src/data_management/dmu.rs
@@ -819,8 +819,8 @@ where
         Ok(obj.into_value().into_inner())
     }
 
-    fn ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef {
-        r.into()
+    fn root_ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef {
+        Self::ObjectRef::root_ref_from_obj_ptr(r)
     }
 
     fn evict(&self) -> Result<(), Error> {

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -1,7 +1,7 @@
 use super::{object_ptr::ObjectPointer, HasStoragePreference};
 use crate::{
     database::Generation,
-    size::{SizeMut, StaticSize},
+    size::{StaticSize},
     storage_pool::DiskOffset,
     tree::PivotKey,
     StoragePreference,

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -1,16 +1,10 @@
 use super::{object_ptr::ObjectPointer, HasStoragePreference};
 use crate::{
-    cache::AddSize, database::Generation, size::{StaticSize, SizeMut}, storage_pool::DiskOffset,
+    database::Generation, size::{StaticSize, SizeMut}, storage_pool::DiskOffset,
     StoragePreference, tree::PivotKey,
 };
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::{
     de::DeserializeOwned, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
-};
-use stable_deref_trait::StableDeref;
-use std::{
-    mem::{transmute, ManuallyDrop},
-    ops::{Deref, DerefMut},
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
@@ -162,116 +156,5 @@ where
     {
         debug!("Deserializing");
         ObjectPointer::<D>::deserialize(deserializer).map(ObjRef::Incomplete)
-    }
-}
-
-pub struct CacheValueRef<T, U> {
-    head: T,
-    guard: ManuallyDrop<U>,
-}
-
-impl<T, U> Drop for CacheValueRef<T, U> {
-    fn drop(&mut self) {
-        unsafe {
-            ManuallyDrop::drop(&mut self.guard);
-        }
-    }
-}
-
-impl<T: AddSize, U> AddSize for CacheValueRef<T, U> {
-    fn add_size(&self, size_delta: isize) {
-        self.head.add_size(size_delta)
-    }
-}
-
-impl<T, U, I> CacheValueRef<T, RwLockReadGuard<'static, U>>
-where
-    T: StableDeref<Target = TaggedCacheValue<RwLock<U>, I>>,
-{
-    pub(super) fn read(head: T) -> Self {
-        let guard = unsafe { transmute(RwLock::read(&head.value)) };
-        CacheValueRef {
-            head,
-            guard: ManuallyDrop::new(guard),
-        }
-    }
-}
-
-impl<T, U, I> CacheValueRef<T, RwLockWriteGuard<'static, U>>
-where
-    T: StableDeref<Target = TaggedCacheValue<RwLock<U>, I>>,
-{
-    pub(super) fn write(head: T) -> Self {
-        let guard = unsafe { transmute(RwLock::write(&head.value)) };
-        CacheValueRef {
-            head,
-            guard: ManuallyDrop::new(guard),
-        }
-    }
-}
-
-unsafe impl<T, U> StableDeref for CacheValueRef<T, RwLockReadGuard<'static, U>> {}
-
-impl<T, U> Deref for CacheValueRef<T, RwLockReadGuard<'static, U>> {
-    type Target = U;
-    fn deref(&self) -> &U {
-        &self.guard
-    }
-}
-
-unsafe impl<T, U> StableDeref for CacheValueRef<T, RwLockWriteGuard<'static, U>> {}
-
-impl<T, U> Deref for CacheValueRef<T, RwLockWriteGuard<'static, U>> {
-    type Target = U;
-    fn deref(&self) -> &U {
-        &self.guard
-    }
-}
-
-impl<T, U> DerefMut for CacheValueRef<T, RwLockWriteGuard<'static, U>> {
-    fn deref_mut(&mut self) -> &mut U {
-        &mut self.guard
-    }
-}
-
-pub struct TaggedCacheValue<Val, Tag> {
-    value: Val,
-    tag: Tag,
-}
-
-impl<Val, Tag> TaggedCacheValue<Val, Tag> {
-    pub fn new(value: Val, tag: Tag) -> Self {
-        Self {
-            value,
-            tag,
-        }
-    }
-
-    pub fn value(&self) -> &Val {
-        &self.value
-    }
-
-    pub fn value_mut(&mut self) -> &mut Val {
-        &mut self.value
-    }
-
-    pub fn into_value(self) -> Val {
-        self.value
-    }
-
-    pub fn tag(&self) -> &Tag {
-        &self.tag
-    }
-}
-
-impl<Val: AddSize, Tag> AddSize for TaggedCacheValue<Val, Tag> {
-    fn add_size(&self, size_delta: isize) {
-        self.value.add_size(size_delta)
-    }
-}
-
-impl<Val: SizeMut, Tag> SizeMut for TaggedCacheValue<Val, Tag> {
-    fn size(&mut self) -> usize {
-        self.value.size()
     }
 }

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -1,7 +1,10 @@
 use super::{object_ptr::ObjectPointer, HasStoragePreference};
 use crate::{
-    database::Generation, size::{StaticSize, SizeMut}, storage_pool::DiskOffset,
-    StoragePreference, tree::PivotKey,
+    database::Generation,
+    size::{SizeMut, StaticSize},
+    storage_pool::DiskOffset,
+    tree::PivotKey,
+    StoragePreference,
 };
 use serde::{
     de::DeserializeOwned, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
@@ -56,12 +59,11 @@ where
         // }
         match self {
             ObjRef::Incomplete(ref p) => *self = ObjRef::Unmodified(p.clone(), pk),
-            ObjRef::Unmodified(_, o_pk) | ObjRef::Modified(_,o_pk ) => *o_pk = pk,
+            ObjRef::Unmodified(_, o_pk) | ObjRef::Modified(_, o_pk) => *o_pk = pk,
             // NOTE: An object reference may never need to be modified when
             // performing a write back.
             ObjRef::InWriteback(..) => unreachable!(),
         }
-
     }
 
     fn index(&self) -> &PivotKey {
@@ -88,8 +90,8 @@ impl<D> ObjRef<ObjectPointer<D>> {
     /// Create an `ObjRef` from the given to the `ObjectPointer` under the
     /// assumption that the pointer belongs to a root object.
     pub fn root_ref_from_obj_ptr(ptr: ObjectPointer<D>) -> Self {
-         let d_id = ptr.info;
-         ObjRef::Unmodified(ptr, PivotKey::Root(d_id))
+        let d_id = ptr.info;
+        ObjRef::Unmodified(ptr, PivotKey::Root(d_id))
     }
 }
 

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -90,12 +90,12 @@ impl<D> ObjRef<ObjectPointer<D>> {
             ObjRef::Incomplete(..) => unreachable!(),
         }
     }
-}
 
-impl<D> From<ObjectPointer<D>> for ObjRef<ObjectPointer<D>> {
-    fn from(ptr: ObjectPointer<D>) -> Self {
-        let d_id = ptr.info;
-        ObjRef::Unmodified(ptr, PivotKey::Root(d_id))
+    /// Create an `ObjRef` from the given to the `ObjectPointer` under the
+    /// assumption that the pointer belongs to a root object.
+    pub fn root_ref_from_obj_ptr(ptr: ObjectPointer<D>) -> Self {
+         let d_id = ptr.info;
+         ObjRef::Unmodified(ptr, PivotKey::Root(d_id))
     }
 }
 

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -231,3 +231,22 @@ impl<T, U> DerefMut for CacheValueRef<T, RwLockWriteGuard<'static, U>> {
         &mut self.guard
     }
 }
+
+pub struct TaggedCacheValue<Val, Tag> {
+    value: Val,
+    tag: Tag,
+}
+
+impl<Val: AddSize, Tag> AddSize for TaggedCacheValue<Val, Tag> {
+    fn add_size(&self, size_delta: isize) {
+        self.value.add_size(size_delta)
+    }
+}
+
+impl<Val, Tag> Deref for TaggedCacheValue<Val, Tag> {
+    type Target = Val;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -89,7 +89,7 @@ pub trait HasStoragePreference {
     fn correct_preference(&self) -> StoragePreference {
         match self.current_preference() {
             Some(pref) => pref,
-
+            None => self.recalculate(),
         }
     }
 
@@ -110,7 +110,7 @@ pub trait Object<R>: Size + Sized + HasStoragePreference {
     /// Packs the object into the given `writer`.
     fn pack<W: Write>(&self, writer: W) -> Result<(), io::Error>;
     /// Unpacks the object from the given `data`.
-    fn unpack_at(disk_offset: DiskOffset, data: Box<[u8]>) -> Result<Self, io::Error>;
+    fn unpack_at(disk_offset: DiskOffset, d_id: DatasetId, data: Box<[u8]>) -> Result<Self, io::Error>;
 
     /// Returns debug information about an object.
     fn debug_info(&self) -> String;

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -256,7 +256,7 @@ pub trait DmlWithHandler {
 /// by the migration policies.
 pub trait DmlWithStorageHints {
     /// Returns a handle to the storage hint data structure.
-    fn storage_hints(&self) -> Arc<Mutex<HashMap<DiskOffset, StoragePreference>>>;
+    fn storage_hints(&self) -> Arc<Mutex<HashMap<PivotKey, StoragePreference>>>;
     /// Returns the default storage class used when [StoragePreference] is `None`.
     fn default_storage_class(&self) -> StoragePreference;
 }

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -276,5 +276,8 @@ mod dmu;
 pub(crate) mod errors;
 pub(crate) mod impls;
 mod object_ptr;
+mod cache_value;
+
+pub(crate) use self::cache_value::TaggedCacheValue;
 
 pub use self::{dmu::Dmu, errors::Error, object_ptr::ObjectPointer};

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -190,7 +190,7 @@ pub trait Dml: Sized {
     fn get_and_remove(&self, or: Self::ObjectRef) -> Result<Self::Object, Error>;
 
     /// Turns an ObjectPointer into an ObjectReference.
-    fn ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef;
+    fn root_ref_from_ptr(r: Self::ObjectPointer) -> Self::ObjectRef;
 
     /// Writes back an object and all its dependencies.
     /// `acquire_or_lock` shall return a lock guard

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -14,10 +14,12 @@
 
 use crate::{
     cache::AddSize,
+    database::DatasetId,
     migration::DmlMsg,
     size::{Size, StaticSize},
     storage_pool::{DiskOffset, StoragePoolLayer},
-    StoragePreference, tree::PivotKey, database::DatasetId,
+    tree::PivotKey,
+    StoragePreference,
 };
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
@@ -110,7 +112,11 @@ pub trait Object<R>: Size + Sized + HasStoragePreference {
     /// Packs the object into the given `writer`.
     fn pack<W: Write>(&self, writer: W) -> Result<(), io::Error>;
     /// Unpacks the object from the given `data`.
-    fn unpack_at(disk_offset: DiskOffset, d_id: DatasetId, data: Box<[u8]>) -> Result<Self, io::Error>;
+    fn unpack_at(
+        disk_offset: DiskOffset,
+        d_id: DatasetId,
+        data: Box<[u8]>,
+    ) -> Result<Self, io::Error>;
 
     /// Returns debug information about an object.
     fn debug_info(&self) -> String;
@@ -271,12 +277,12 @@ pub trait DmlWithReport {
     fn set_report(&mut self, tx: Sender<DmlMsg>);
 }
 
+mod cache_value;
 mod delegation;
 mod dmu;
 pub(crate) mod errors;
 pub(crate) mod impls;
 mod object_ptr;
-mod cache_value;
 
 pub(crate) use self::cache_value::TaggedCacheValue;
 

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -596,6 +596,22 @@ impl Dataset<DefaultMessageAction> {
         self.inner.read().upsert(key, data, offset)
     }
 
+    /// Immutably fetch a given node by its pivot key.
+    pub(crate) fn get_node_pivot(
+        &self,
+        pk: &PivotKey,
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRef>> {
+        self.inner.read().get_node_pivot(pk)
+    }
+
+    /// Mutably fetch a given node by its pivot key.
+    pub(crate) fn get_node_pivot_mut(
+        &self,
+        pk: &PivotKey,
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRefMut>> {
+        self.inner.read().get_node_pivot_mut(pk)
+    }
+
     #[cfg(feature = "internal-api")]
     pub fn test_get_node_pivot(
         &self,

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -6,7 +6,7 @@ use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::Dml,
     migration::DatabaseMsg,
-    tree::{self, DefaultMessageAction, MessageAction, NodeInfo, PivotKey, Tree, TreeLayer},
+    tree::{self, DefaultMessageAction, MessageAction, PivotKey, Tree, TreeLayer},
     StoragePreference,
 };
 use parking_lot::RwLock;

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -9,6 +9,10 @@ use crate::{
     tree::{self, DefaultMessageAction, MessageAction, PivotKey, Tree, TreeLayer},
     StoragePreference,
 };
+
+#[cfg(feature = "internal-api")]
+use crate::tree::NodeInfo;
+
 use parking_lot::RwLock;
 use std::{borrow::Borrow, collections::HashSet, ops::RangeBounds, sync::Arc};
 

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -287,7 +287,7 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
     pub(crate) fn get_node_pivot(
         &self,
         pk: &PivotKey,
-    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRef>> {
         debug_assert!(self.id == pk.d_id());
         Ok(self.tree.get_node_pivot(pk)?)
     }
@@ -296,7 +296,7 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
     pub(crate) fn get_node_pivot_mut(
         &self,
         pk: &PivotKey,
-    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRefMut>> {
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRefMut>> {
         debug_assert!(self.id == pk.d_id());
         Ok(self.tree.get_mut_node_pivot(pk)?)
     }
@@ -305,7 +305,7 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
     pub fn test_get_node_pivot(
         &self,
         pk: &PivotKey,
-    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRef>> {
         debug_assert!(self.id == pk.d_id());
         Ok(self.tree.get_node_pivot(pk)?)
     }
@@ -601,7 +601,7 @@ impl Dataset<DefaultMessageAction> {
     pub fn test_get_node_pivot(
         &self,
         pk: &PivotKey,
-    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+    ) -> Result<Option<<RootDmu as Dml>::CacheValueRef>> {
         self.inner.read().test_get_node_pivot(pk)
     }
 

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -6,7 +6,7 @@ use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, DmlWithHandler},
     migration::DatabaseMsg,
-    tree::{self, DefaultMessageAction, MessageAction, Tree, TreeLayer},
+    tree::{self, DefaultMessageAction, MessageAction, Tree, TreeLayer, PivotKey},
     StoragePreference,
 };
 use parking_lot::RwLock;
@@ -283,12 +283,16 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
         Ok(self.tree.get(key)?)
     }
 
-    pub(crate) fn get_node_pivot<K: Borrow<[u8]>>(&self, pivot: K) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
-        Ok(self.tree.get_node_pivot(pivot)?)
+    /// Immutably fetch a given node by its pivot key.
+    pub(crate) fn get_node_pivot(&self, pk: &PivotKey) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+        debug_assert!(self.id == pk.d_id());
+        Ok(self.tree.get_node_pivot(pk)?)
     }
 
-    pub(crate) fn get_node_pivot_mut<K: Borrow<[u8]>>(&self, pivot: K) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
-        Ok(self.tree.get_node_pivot(pivot)?)
+    /// Mutably fetch a given node by its pivot key.
+    pub(crate) fn get_node_pivot_mut(&self, pk: &PivotKey) -> Result<Option<<Config::Dmu as Dml>::CacheValueRefMut>> {
+        debug_assert!(self.id == pk.d_id());
+        Ok(self.tree.get_mut_node_pivot(pk)?)
     }
 
     /// Iterates over all key-value pairs in the given key range.

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -6,7 +6,7 @@ use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, DmlWithHandler},
     migration::DatabaseMsg,
-    tree::{self, DefaultMessageAction, MessageAction, Tree, TreeLayer, PivotKey},
+    tree::{self, DefaultMessageAction, MessageAction, PivotKey, Tree, TreeLayer},
     StoragePreference,
 };
 use parking_lot::RwLock;
@@ -284,13 +284,19 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
     }
 
     /// Immutably fetch a given node by its pivot key.
-    pub(crate) fn get_node_pivot(&self, pk: &PivotKey) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+    pub(crate) fn get_node_pivot(
+        &self,
+        pk: &PivotKey,
+    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
         debug_assert!(self.id == pk.d_id());
         Ok(self.tree.get_node_pivot(pk)?)
     }
 
     /// Mutably fetch a given node by its pivot key.
-    pub(crate) fn get_node_pivot_mut(&self, pk: &PivotKey) -> Result<Option<<Config::Dmu as Dml>::CacheValueRefMut>> {
+    pub(crate) fn get_node_pivot_mut(
+        &self,
+        pk: &PivotKey,
+    ) -> Result<Option<<Config::Dmu as Dml>::CacheValueRefMut>> {
         debug_assert!(self.id == pk.d_id());
         Ok(self.tree.get_mut_node_pivot(pk)?)
     }

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
-    data_management::{Dml, DmlWithHandler},
+    data_management::Dml,
     migration::DatabaseMsg,
     tree::{self, DefaultMessageAction, MessageAction, NodeInfo, PivotKey, Tree, TreeLayer},
     StoragePreference,

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -6,7 +6,7 @@ use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, DmlWithHandler},
     migration::DatabaseMsg,
-    tree::{self, DefaultMessageAction, MessageAction, PivotKey, Tree, TreeLayer, NodeInfo},
+    tree::{self, DefaultMessageAction, MessageAction, NodeInfo, PivotKey, Tree, TreeLayer},
     StoragePreference,
 };
 use parking_lot::RwLock;
@@ -595,7 +595,6 @@ impl Dataset<DefaultMessageAction> {
     ) -> Result<()> {
         self.inner.read().upsert(key, data, offset)
     }
-
 
     #[cfg(feature = "internal-api")]
     pub fn test_get_node_pivot(

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -283,6 +283,14 @@ impl<Message: MessageAction + 'static> DatasetInner<Message> {
         Ok(self.tree.get(key)?)
     }
 
+    pub(crate) fn get_node_pivot<K: Borrow<[u8]>>(&self, pivot: K) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+        Ok(self.tree.get_node_pivot(pivot)?)
+    }
+
+    pub(crate) fn get_node_pivot_mut<K: Borrow<[u8]>>(&self, pivot: K) -> Result<Option<<Config::Dmu as Dml>::CacheValueRef>> {
+        Ok(self.tree.get_node_pivot(pivot)?)
+    }
+
     /// Iterates over all key-value pairs in the given key range.
     pub fn range<R, K>(
         &self,

--- a/betree/src/database/handler.rs
+++ b/betree/src/database/handler.rs
@@ -37,8 +37,8 @@ pub fn update_allocation_bitmap_msg(
 /// The database handler, holding management data for interactions
 /// between the database and data management layers.
 pub struct Handler<OR: ObjectReference> {
-    pub(crate) root_tree_inner: AtomicOption<Arc<TreeInner<OR, DatasetId, DefaultMessageAction>>>,
-    pub(crate) root_tree_snapshot: RwLock<Option<TreeInner<OR, DatasetId, DefaultMessageAction>>>,
+    pub(crate) root_tree_inner: AtomicOption<Arc<TreeInner<OR, DefaultMessageAction>>>,
+    pub(crate) root_tree_snapshot: RwLock<Option<TreeInner<OR, DefaultMessageAction>>>,
     pub(crate) current_generation: SeqLock<Generation>,
     // Free Space counted as blocks
     pub(crate) free_space: HashMap<(u8, u16), AtomicStorageInfo>,
@@ -63,7 +63,6 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             Object = Node<OR>,
             ObjectRef = OR,
             ObjectPointer = OR::ObjectPointer,
-            Info = DatasetId,
         >,
     {
         Tree::from_inner(
@@ -83,7 +82,6 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             Object = Node<OR>,
             ObjectRef = OR,
             ObjectPointer = OR::ObjectPointer,
-            Info = DatasetId,
         >,
     {
         OwningRef::new(self.root_tree_snapshot.read())
@@ -120,7 +118,6 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             Object = Node<OR>,
             ObjectRef = OR,
             ObjectPointer = OR::ObjectPointer,
-            Info = DatasetId,
         >,
     {
         self.allocations.fetch_add(1, Ordering::Release);
@@ -160,7 +157,6 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             Object = Node<OR>,
             ObjectRef = OR,
             ObjectPointer = OR::ObjectPointer,
-            Info = DatasetId,
         >,
     {
         let now = std::time::Instant::now();

--- a/betree/src/database/handler.rs
+++ b/betree/src/database/handler.rs
@@ -59,11 +59,7 @@ pub struct Handler<OR: ObjectReference> {
 impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
     fn current_root_tree<'a, X>(&'a self, dmu: &'a X) -> impl TreeLayer<DefaultMessageAction> + 'a
     where
-        X: Dml<
-            Object = Node<OR>,
-            ObjectRef = OR,
-            ObjectPointer = OR::ObjectPointer,
-        >,
+        X: Dml<Object = Node<OR>, ObjectRef = OR, ObjectPointer = OR::ObjectPointer>,
     {
         Tree::from_inner(
             self.root_tree_inner.get().unwrap().as_ref(),
@@ -78,11 +74,7 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
         dmu: &'a X,
     ) -> Option<impl TreeLayer<DefaultMessageAction> + 'a>
     where
-        X: Dml<
-            Object = Node<OR>,
-            ObjectRef = OR,
-            ObjectPointer = OR::ObjectPointer,
-        >,
+        X: Dml<Object = Node<OR>, ObjectRef = OR, ObjectPointer = OR::ObjectPointer>,
     {
         OwningRef::new(self.root_tree_snapshot.read())
             .try_map(|lock| lock.as_ref().ok_or(()))
@@ -114,11 +106,7 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
         dmu: &X,
     ) -> Result<()>
     where
-        X: Dml<
-            Object = Node<OR>,
-            ObjectRef = OR,
-            ObjectPointer = OR::ObjectPointer,
-        >,
+        X: Dml<Object = Node<OR>, ObjectRef = OR, ObjectPointer = OR::ObjectPointer>,
     {
         self.allocations.fetch_add(1, Ordering::Release);
         let key = segment_id_to_key(SegmentId::get(offset));
@@ -153,11 +141,7 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
 
     pub fn get_allocation_bitmap<X>(&self, id: SegmentId, dmu: &X) -> Result<SegmentAllocator>
     where
-        X: Dml<
-            Object = Node<OR>,
-            ObjectRef = OR,
-            ObjectPointer = OR::ObjectPointer,
-        >,
+        X: Dml<Object = Node<OR>, ObjectRef = OR, ObjectPointer = OR::ObjectPointer>,
     {
         let now = std::time::Instant::now();
         let mut bitmap = [0u8; SEGMENT_SIZE_BYTES];

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -73,7 +73,7 @@ pub(crate) type RootDmu =
     Dmu<ClockCache<data_management::impls::ObjectKey<Generation>, RwLock<Object>>, RootSpu>;
 
 pub(crate) type MessageTree<Dmu, Message> =
-    Tree<Arc<Dmu>, Message, Arc<TreeInner<ObjectRef, DatasetId, Message>>>;
+    Tree<Arc<Dmu>, Message, Arc<TreeInner<ObjectRef, Message>>>;
 
 pub(crate) type RootTree<Dmu> = MessageTree<Dmu, DefaultMessageAction>;
 pub(crate) type DatasetTree<Dmu> = RootTree<Dmu>;

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -401,7 +401,7 @@ impl Database {
 
         *tree.dmu().handler().current_generation.lock_write() = root_ptr.generation().next();
         *tree.dmu().handler().root_tree_snapshot.write() = Some(TreeInner::new_ro(
-            RootDmu::ref_from_ptr(root_ptr),
+            RootDmu::root_ref_from_ptr(root_ptr),
             DefaultMessageAction,
         ));
 
@@ -563,7 +563,7 @@ impl Database {
             .write()
             .as_mut()
             .unwrap()
-            .update_root_node(RootDmu::ref_from_ptr(root_ptr));
+            .update_root_node(RootDmu::root_ref_from_ptr(root_ptr));
         Ok(())
     }
 

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         DiskOffset, StoragePoolConfiguration, StoragePoolLayer, StoragePoolUnit,
         NUM_STORAGE_CLASSES,
     },
-    tree::{DefaultMessageAction, ErasedTreeSync, Inner as TreeInner, Node, Tree, TreeLayer},
+    tree::{DefaultMessageAction, ErasedTreeSync, Inner as TreeInner, Node, Tree, TreeLayer, PivotKey},
     vdev::Block,
     StoragePreference,
 };

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     checksum::{XxHash, XxHashBuilder},
     compression::CompressionConfiguration,
     cow_bytes::SlicedCowBytes,
-    data_management::{self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu, impls::TaggedCacheValue},
+    data_management::{self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu, TaggedCacheValue},
     metrics::{metrics_init, MetricsConfiguration},
     migration::{DatabaseMsg, DmlMsg, GlobalObjectId, MigrationPolicies},
     size::StaticSize,

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     checksum::{XxHash, XxHashBuilder},
     compression::CompressionConfiguration,
     cow_bytes::SlicedCowBytes,
-    data_management::{self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu},
+    data_management::{self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu, impls::TaggedCacheValue},
     metrics::{metrics_init, MetricsConfiguration},
     migration::{DatabaseMsg, DmlMsg, GlobalObjectId, MigrationPolicies},
     size::StaticSize,
@@ -69,8 +69,11 @@ pub(crate) type Object = Node<ObjectRef>;
 type DbHandler = Handler<ObjectRef>;
 
 pub(crate) type RootSpu = StoragePoolUnit<XxHash>;
-pub(crate) type RootDmu =
-    Dmu<ClockCache<data_management::impls::ObjectKey<Generation>, RwLock<Object>>, RootSpu>;
+
+pub(crate) type RootDmu = Dmu<
+    ClockCache<data_management::impls::ObjectKey<Generation>, TaggedCacheValue<RwLock<Object>, PivotKey>>,
+    RootSpu,
+>;
 
 pub(crate) type MessageTree<Dmu, Message> =
     Tree<Arc<Dmu>, Message, Arc<TreeInner<ObjectRef, Message>>>;

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -69,7 +69,6 @@ pub(crate) type Object = Node<ObjectRef>;
 type DbHandler = Handler<ObjectRef>;
 
 pub(crate) type RootSpu = StoragePoolUnit<XxHash>;
-
 pub(crate) type RootDmu = Dmu<
     ClockCache<data_management::impls::ObjectKey<Generation>, TaggedCacheValue<RwLock<Object>, PivotKey>>,
     RootSpu,

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     checksum::{XxHash, XxHashBuilder},
     compression::CompressionConfiguration,
     cow_bytes::SlicedCowBytes,
-    data_management::{self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu, TaggedCacheValue},
+    data_management::{
+        self, Dml, DmlWithHandler, DmlWithReport, DmlWithStorageHints, Dmu, TaggedCacheValue,
+    },
     metrics::{metrics_init, MetricsConfiguration},
     migration::{DatabaseMsg, DmlMsg, GlobalObjectId, MigrationPolicies},
     size::StaticSize,
@@ -13,7 +15,9 @@ use crate::{
         DiskOffset, StoragePoolConfiguration, StoragePoolLayer, StoragePoolUnit,
         NUM_STORAGE_CLASSES,
     },
-    tree::{DefaultMessageAction, ErasedTreeSync, Inner as TreeInner, Node, Tree, TreeLayer, PivotKey},
+    tree::{
+        DefaultMessageAction, ErasedTreeSync, Inner as TreeInner, Node, PivotKey, Tree, TreeLayer,
+    },
     vdev::Block,
     StoragePreference,
 };
@@ -70,7 +74,10 @@ type DbHandler = Handler<ObjectRef>;
 
 pub(crate) type RootSpu = StoragePoolUnit<XxHash>;
 pub(crate) type RootDmu = Dmu<
-    ClockCache<data_management::impls::ObjectKey<Generation>, TaggedCacheValue<RwLock<Object>, PivotKey>>,
+    ClockCache<
+        data_management::impls::ObjectKey<Generation>,
+        TaggedCacheValue<RwLock<Object>, PivotKey>,
+    >,
     RootSpu,
 >;
 

--- a/betree/src/database/storage_info.rs
+++ b/betree/src/database/storage_info.rs
@@ -31,6 +31,15 @@ impl StorageInfo {
                 .clamp(0.0, f32::MAX) as u64,
         )
     }
+
+    pub fn blocks_until_filled_to(&self, threshold: f32) -> Block<u64> {
+        let threshold = threshold.clamp(0.0, 1.0);
+        Block(
+            (self.total.0 as f32 * threshold - (self.total.0 - self.free.0) as f32)
+                .ceil()
+                .clamp(0.0, f32::MAX) as u64,
+        )
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/betree/src/migration/lfu.rs
+++ b/betree/src/migration/lfu.rs
@@ -279,7 +279,7 @@ impl super::MigrationPolicy for Lfu {
                     if up_freq < freq || !tight_space {
                         moved += self.migrate_object_from_to(
                             object_id.clone(),
-                            &name,
+                            name,
                             StoragePreference::from_u8(storage_tier),
                             target,
                         )?;
@@ -341,7 +341,7 @@ impl super::MigrationPolicy for Lfu {
                 {
                     moved += self.migrate_object_from_to(
                         object_id.clone(),
-                        &name,
+                        name,
                         StoragePreference::from_u8(storage_tier),
                         target,
                     )?;

--- a/betree/src/migration/lfu.rs
+++ b/betree/src/migration/lfu.rs
@@ -15,8 +15,9 @@ use crate::{
     database::RootDmu,
     object::{ObjectStore, ObjectStoreId},
     storage_pool::{DiskOffset, NUM_STORAGE_CLASSES},
+    tree::PivotKey,
     vdev::Block,
-    Database, StoragePreference, tree::PivotKey,
+    Database, StoragePreference,
 };
 
 use super::{
@@ -472,7 +473,9 @@ impl super::MigrationPolicy for Lfu {
                     && num_moved < self.config.policy_config.promote_num
                     && !self.leafs[storage_tier as usize].is_empty()
                 {
-                    if let Some((key, entry)) = self.leafs[storage_tier as usize].pop_mfu_key_value() {
+                    if let Some((key, entry)) =
+                        self.leafs[storage_tier as usize].pop_mfu_key_value()
+                    {
                         if let Some(lifted) = StoragePreference::from_u8(storage_tier).lift() {
                             debug!("Moving {:?}", &key);
                             debug!("Was on storage tier: {:?}", storage_tier);
@@ -592,7 +595,9 @@ impl super::MigrationPolicy for Lfu {
             }
             LfuMode::Node => {
                 while moved < desired && !self.leafs[storage_tier as usize].is_empty() {
-                    if let Some((key, entry)) = self.leafs[storage_tier as usize].pop_lfu_key_value() {
+                    if let Some((key, entry)) =
+                        self.leafs[storage_tier as usize].pop_lfu_key_value()
+                    {
                         if let Some(lowered) = StoragePreference::from_u8(storage_tier).lower() {
                             debug!("Moving {:?}", entry.offset);
                             debug!("Was on storage tier: {:?}", storage_tier);

--- a/betree/src/migration/mod.rs
+++ b/betree/src/migration/mod.rs
@@ -84,7 +84,7 @@ use std::{collections::HashMap, sync::Arc};
 use crate::{
     data_management::DmlWithHandler,
     database::RootDmu,
-    storage_pool::{DiskOffset, NUM_STORAGE_CLASSES},
+    storage_pool::{NUM_STORAGE_CLASSES},
     tree::PivotKey,
     vdev::Block,
     Database, StoragePreference,

--- a/betree/src/migration/mod.rs
+++ b/betree/src/migration/mod.rs
@@ -86,7 +86,7 @@ use crate::{
     database::RootDmu,
     storage_pool::{DiskOffset, NUM_STORAGE_CLASSES},
     vdev::Block,
-    Database, StoragePreference,
+    Database, StoragePreference, tree::PivotKey,
 };
 
 use self::{lfu::Lfu, reinforcment_learning::ZhangHellanderToor};
@@ -134,7 +134,7 @@ impl MigrationPolicies {
         dml_rx: Receiver<DmlMsg>,
         db_rx: Receiver<DatabaseMsg>,
         db: Arc<RwLock<Database>>,
-        storage_hint_sink: Arc<Mutex<HashMap<DiskOffset, StoragePreference>>>,
+        storage_hint_sink: Arc<Mutex<HashMap<PivotKey, StoragePreference>>>,
     ) -> Box<dyn MigrationPolicy> {
         match self {
             MigrationPolicies::Lfu(config) => {

--- a/betree/src/migration/mod.rs
+++ b/betree/src/migration/mod.rs
@@ -85,8 +85,9 @@ use crate::{
     data_management::DmlWithHandler,
     database::RootDmu,
     storage_pool::{DiskOffset, NUM_STORAGE_CLASSES},
+    tree::PivotKey,
     vdev::Block,
-    Database, StoragePreference, tree::PivotKey,
+    Database, StoragePreference,
 };
 
 use self::{lfu::Lfu, reinforcment_learning::ZhangHellanderToor};

--- a/betree/src/migration/msg.rs
+++ b/betree/src/migration/msg.rs
@@ -3,8 +3,9 @@ use crate::{
     database::DatasetId,
     object::{ObjectId, ObjectInfo, ObjectStore, ObjectStoreId},
     storage_pool::DiskOffset,
+    tree::PivotKey,
     vdev::Block,
-    StoragePreference, tree::PivotKey,
+    StoragePreference,
 };
 use std::{
     fmt::Display,
@@ -106,11 +107,7 @@ impl DmlMsg {
         })
     }
 
-    pub fn write(
-        offset: DiskOffset,
-        size: Block<u32>,
-        pivot_key: PivotKey,
-    ) -> Self {
+    pub fn write(offset: DiskOffset, size: Block<u32>, pivot_key: PivotKey) -> Self {
         Self::Write(OpInfo {
             offset,
             size,

--- a/betree/src/migration/reinforcment_learning.rs
+++ b/betree/src/migration/reinforcment_learning.rs
@@ -1126,7 +1126,11 @@ impl MigrationPolicy for ZhangHellanderToor {
         Ok(())
     }
 
-    fn promote(&mut self, _storage_tier: u8) -> super::errors::Result<crate::vdev::Block<u64>> {
+    fn promote(
+        &mut self,
+        _storage_tier: u8,
+        _tight_space: bool,
+    ) -> super::errors::Result<crate::vdev::Block<u64>> {
         unimplemented!()
     }
 

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -44,6 +44,7 @@
 //! Could easily have per-object chunk size, by storing block size in meta chunk
 //! Con: Necessary read per object open (but not create), possibly not worth it
 
+#![allow(missing_docs)]
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::Dml,

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -7,7 +7,7 @@ use crate::{
     data_management::{HasStoragePreference, ObjectReference},
     size::{Size, StaticSize},
     storage_pool::{AtomicSystemStoragePreference, StoragePreferenceBound},
-    tree::{KeyInfo, MessageAction, PivotKey, pivot_key::LocalPivotKey},
+    tree::{pivot_key::LocalPivotKey, KeyInfo, MessageAction, PivotKey},
     AtomicStoragePreference, StoragePreference,
 };
 use parking_lot::RwLock;
@@ -88,7 +88,6 @@ impl<N: ObjectReference> ChildBuffer<N> {
     pub fn complete_object_ref(&mut self, pk: PivotKey) {
         self.node_pointer.get_mut().set_index(pk)
     }
-
 }
 
 mod ser_np {

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -81,6 +81,14 @@ impl<N: ObjectReference> ChildBuffer<N> {
         let d_id = or.index().d_id();
         or.set_index(lpk.to_global(d_id));
     }
+
+    /// Insert an arbitrary PivotKey into the `ObjectReference`.
+    ///
+    /// FIXME: This is best replaced with actual type exclusion.
+    pub fn complete_object_ref(&mut self, pk: PivotKey) {
+        self.node_pointer.get_mut().set_index(pk)
+    }
+
 }
 
 mod ser_np {

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -4,10 +4,10 @@
 //! [super::leaf::LeafNode].
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
-    data_management::HasStoragePreference,
+    data_management::{HasStoragePreference, ObjectReference},
     size::{Size, StaticSize},
-    storage_pool::AtomicSystemStoragePreference,
-    tree::{KeyInfo, MessageAction},
+    storage_pool::{AtomicSystemStoragePreference, StoragePreferenceBound},
+    tree::{KeyInfo, MessageAction, PivotKey, pivot_key::LocalPivotKey},
     AtomicStoragePreference, StoragePreference,
 };
 use parking_lot::RwLock;
@@ -70,6 +70,16 @@ impl<N: HasStoragePreference> HasStoragePreference for ChildBuffer<N> {
 
     fn set_system_storage_preference(&mut self, pref: StoragePreference) {
         self.system_storage_preference.set(pref)
+    }
+}
+
+impl<N: ObjectReference> ChildBuffer<N> {
+    /// Access the pivot key of the underlying object reference and update it to
+    /// reflect a structural change in the tree.
+    pub fn update_pivot_key(&mut self, lpk: LocalPivotKey) {
+        let or = self.node_pointer.get_mut();
+        let d_id = or.index().d_id();
+        or.set_index(lpk.to_global(d_id));
     }
 }
 

--- a/betree/src/tree/imp/child_buffer.rs
+++ b/betree/src/tree/imp/child_buffer.rs
@@ -6,7 +6,7 @@ use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{HasStoragePreference, ObjectReference},
     size::{Size, StaticSize},
-    storage_pool::{AtomicSystemStoragePreference, StoragePreferenceBound},
+    storage_pool::AtomicSystemStoragePreference,
     tree::{pivot_key::LocalPivotKey, KeyInfo, MessageAction, PivotKey},
     AtomicStoragePreference, StoragePreference,
 };

--- a/betree/src/tree/imp/flush.rs
+++ b/betree/src/tree/imp/flush.rs
@@ -21,7 +21,7 @@ where
     X: Dml<Object = Node<R>, ObjectRef = R>,
     R: ObjectReference<ObjectPointer = X::ObjectPointer> + HasStoragePreference,
     M: MessageAction,
-    I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
+    I: Borrow<Inner<X::ObjectRef, M>>,
 {
     /// This method performs necessary flushing and rebalancing operations if
     /// too many entries are stored at a node. We use this method immediately

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -7,10 +7,11 @@ use super::{
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{HasStoragePreference, ObjectReference},
+    database::DatasetId,
     size::{Size, SizeMut, StaticSize},
     storage_pool::AtomicSystemStoragePreference,
-    tree::{KeyInfo, MessageAction, pivot_key::LocalPivotKey},
-    AtomicStoragePreference, StoragePreference, database::DatasetId,
+    tree::{pivot_key::LocalPivotKey, KeyInfo, MessageAction},
+    AtomicStoragePreference, StoragePreference,
 };
 use bincode::serialized_size;
 use parking_lot::RwLock;

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -882,6 +882,18 @@ mod tests {
         TestResult::passed()
     }
 
+    #[quickcheck]
+    fn check_split_key(mut node: InternalNode<ChildBuffer<()>>) -> TestResult {
+        if node.fanout() < 4 {
+            return TestResult::discard();
+        }
+        let (right_sibling, pivot, _size_delta, pivot_key) = node.split();
+        assert!(node.fanout() >= 2);
+        assert!(right_sibling.fanout() >= 2);
+        assert_eq!(LocalPivotKey::Right(pivot), pivot_key);
+        TestResult::passed()
+    }
+
     // #[test]
     // fn check_constant() {
     //     let node: InternalNode<ChildBuffer<()>> = InternalNode {

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -655,7 +655,7 @@ impl<'a, N: Size + HasStoragePreference> TakeChildBuffer<'a, ChildBuffer<N>> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    
 
     use super::*;
     use crate::{
@@ -664,7 +664,7 @@ mod tests {
         tree::default_message_action::{DefaultMessageAction, DefaultMessageActionMsg},
     };
     use bincode::serialized_size;
-    use owning_ref::BoxRef;
+    
     use quickcheck::{Arbitrary, Gen, TestResult};
     use rand::Rng;
     use serde::Serialize;
@@ -831,7 +831,7 @@ mod tests {
             Some(&())
         }
 
-        fn set_index(&mut self, pk: PivotKey) {
+        fn set_index(&mut self, _pk: PivotKey) {
             // NO-OP
         }
 

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -6,7 +6,7 @@ use crate::{
     size::{Size, SizeMut, StaticSize},
     storage_pool::AtomicSystemStoragePreference,
     tree::{KeyInfo, MessageAction, pivot_key::LocalPivotKey},
-    AtomicStoragePreference, StoragePreference,
+    AtomicStoragePreference, StoragePreference, database::DatasetId,
 };
 use bincode::serialized_size;
 use parking_lot::RwLock;
@@ -424,7 +424,7 @@ impl<N: ObjectReference> InternalNode<ChildBuffer<N>> {
             system_storage_preference: self.system_storage_preference.clone(),
             pref: AtomicStoragePreference::unknown(),
         };
-        (right_sibling, pivot_key, -(size_delta as isize), LocalPivotKey::Right(pivot_key))
+        (right_sibling, pivot_key.clone(), -(size_delta as isize), LocalPivotKey::Right(pivot_key))
     }
 
     pub fn merge(&mut self, right_sibling: &mut Self, old_pivot_key: CowBytes) -> isize {
@@ -436,6 +436,21 @@ impl<N: ObjectReference> InternalNode<ChildBuffer<N>> {
         self.children.append(&mut right_sibling.children);
 
         size_delta as isize
+    }
+
+    /// Translate any object ref in a `ChildBuffer` from `Incomplete` to `Unmodified` state.
+    pub fn complete_object_refs(mut self, d_id: DatasetId) -> Self {
+        // TODO:
+        let first_pk = match self.pivot.first() {
+            Some(p) => PivotKey::LeftOuter(p.clone(), d_id),
+            None => unreachable!("The store contains an empty InternalNode, this should never be the case."),
+        };
+        for (id,pk) in [first_pk].into_iter().chain(self.pivot.iter().map(|p| PivotKey::Right(p.clone(), d_id))).enumerate() {
+            // SAFETY: There must always be pivots + 1 many children, otherwise
+            // the state of the Internal Node is broken.
+            self.children[id].complete_object_ref(pk)
+        }
+        self
     }
 }
 
@@ -618,12 +633,15 @@ impl<'a, N: Size + HasStoragePreference> TakeChildBuffer<'a, ChildBuffer<N>> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
     use crate::{
         arbitrary::GenExt,
-        tree::default_message_action::{DefaultMessageAction, DefaultMessageActionMsg},
+        tree::default_message_action::{DefaultMessageAction, DefaultMessageActionMsg}, database::DatasetId,
     };
     use bincode::serialized_size;
+    use owning_ref::BoxRef;
     use quickcheck::{Arbitrary, Gen, TestResult};
     use rand::Rng;
     use serde::Serialize;
@@ -752,6 +770,7 @@ mod tests {
         check_size(&mut node);
     }
 
+
     #[quickcheck]
     fn check_insert_msg_buffer(
         mut node: InternalNode<ChildBuffer<()>>,
@@ -781,13 +800,36 @@ mod tests {
         assert_eq!(added_size, added_size_twin);
     }
 
+    static mut PK: Option<PivotKey> = None;
+
+    impl ObjectReference for () {
+        type ObjectPointer = ();
+
+        fn get_unmodified(&self) -> Option<&Self::ObjectPointer> {
+            Some(&())
+    }
+
+        fn set_index(&mut self, pk: PivotKey) {
+            // NO-OP
+    }
+
+        fn index(&self) -> &PivotKey {
+            unsafe {
+            if PK.is_none() {
+                PK = Some(PivotKey::LeftOuter(CowBytes::from(vec![42u8]), DatasetId::default()));
+            }
+            PK.as_ref().unwrap()
+            }
+    }
+    }
+
     #[quickcheck]
     fn check_size_split(mut node: InternalNode<ChildBuffer<()>>) -> TestResult {
         if node.fanout() < 2 {
             return TestResult::discard();
         }
         let size_before = node.size();
-        let (mut right_sibling, _pivot_key, size_delta) = node.split();
+        let (mut right_sibling, _pivot, size_delta, _pivot_key) = node.split();
         assert_eq!(size_before as isize + size_delta, node.size() as isize);
         check_size(&mut node);
         check_size(&mut right_sibling);
@@ -801,13 +843,13 @@ mod tests {
             return TestResult::discard();
         }
         let twin = node.clone();
-        let (mut right_sibling, pivot_key, _size_delta) = node.split();
+        let (mut right_sibling, pivot, _size_delta, _pivot_key) = node.split();
 
         assert!(node.fanout() >= 2);
         assert!(right_sibling.fanout() >= 2);
 
-        node.entries_size += pivot_key.size() + right_sibling.entries_size;
-        node.pivot.push(pivot_key);
+        node.entries_size += pivot.size() + right_sibling.entries_size;
+        node.pivot.push(pivot);
         node.pivot.append(&mut right_sibling.pivot);
         node.children.append(&mut right_sibling.children);
 

--- a/betree/src/tree/imp/internal.rs
+++ b/betree/src/tree/imp/internal.rs
@@ -218,7 +218,7 @@ impl<N> InternalNode<ChildBuffer<N>> {
                     } else {
                         child = &self.children[idx + 1];
                     }
-                    PivotGetResult::Target(&child.node_pointer)
+                    PivotGetResult::Target(Some(&child.node_pointer))
                 },
             )
     }
@@ -242,8 +242,8 @@ impl<N> InternalNode<ChildBuffer<N>> {
                 },
             );
         match (is_target, pk.is_left()) {
-            (true, true) => PivotGetMutResult::Target(self.children[id].node_pointer.get_mut()),
-            (true, false) => PivotGetMutResult::Target(self.children[id + 1].node_pointer.get_mut()),
+            (true, true) => PivotGetMutResult::Target(Some(self.children[id].node_pointer.get_mut())),
+            (true, false) => PivotGetMutResult::Target(Some(self.children[id + 1].node_pointer.get_mut())),
             (false, _) => PivotGetMutResult::NextNode(self.children[id].node_pointer.get_mut()),
         }
     }

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -296,7 +296,7 @@ impl LeafNode {
         // This adjusts sibling's size and pref according to its new entries
         let (pivot_key, size_delta) = self.do_split_off(&mut right_sibling, min_size, max_size);
 
-        (right_sibling, pivot_key, size_delta, LocalPivotKey::Right(pivot_key))
+        (right_sibling, pivot_key.clone(), size_delta, LocalPivotKey::Right(pivot_key))
     }
 
     /// Merge all entries from the *right* node into the *left* node.  Returns
@@ -484,7 +484,7 @@ mod tests {
             return TestResult::discard();
         }
 
-        let (sibling, _, size_delta) = leaf_node.split(MIN_LEAF_SIZE, MAX_LEAF_SIZE);
+        let (sibling, _, size_delta, _pivot_key) = leaf_node.split(MIN_LEAF_SIZE, MAX_LEAF_SIZE);
         assert_eq!({ serialized_size(&leaf_node) }, leaf_node.size());
         assert_eq!({ serialized_size(&sibling) }, sibling.size());
         assert_eq!(
@@ -503,7 +503,7 @@ mod tests {
             return TestResult::discard();
         }
         let this = leaf_node.clone();
-        let (mut sibling, _, _) = leaf_node.split(MIN_LEAF_SIZE, MAX_LEAF_SIZE);
+        let (mut sibling, ..) = leaf_node.split(MIN_LEAF_SIZE, MAX_LEAF_SIZE);
         leaf_node.recalculate();
         leaf_node.merge(&mut sibling);
         assert_eq!(this, leaf_node);

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -282,7 +282,11 @@ impl LeafNode {
     /// Splits this `LeafNode` into to two leaf nodes.
     /// Returns a new right sibling, the corresponding pivot key, and the size
     /// delta of this node.
-    pub fn split(&mut self, min_size: usize, max_size: usize) -> (Self, CowBytes, isize, LocalPivotKey) {
+    pub fn split(
+        &mut self,
+        min_size: usize,
+        max_size: usize,
+    ) -> (Self, CowBytes, isize, LocalPivotKey) {
         // assert!(self.size() > S::MAX);
         let mut right_sibling = LeafNode {
             // During a split, preference can't be inherited because the new subset of entries
@@ -296,7 +300,12 @@ impl LeafNode {
         // This adjusts sibling's size and pref according to its new entries
         let (pivot_key, size_delta) = self.do_split_off(&mut right_sibling, min_size, max_size);
 
-        (right_sibling, pivot_key.clone(), size_delta, LocalPivotKey::Right(pivot_key))
+        (
+            right_sibling,
+            pivot_key.clone(),
+            size_delta,
+            LocalPivotKey::Right(pivot_key),
+        )
     }
 
     /// Merge all entries from the *right* node into the *left* node.  Returns

--- a/betree/src/tree/imp/leaf.rs
+++ b/betree/src/tree/imp/leaf.rs
@@ -4,7 +4,7 @@ use crate::{
     data_management::HasStoragePreference,
     size::Size,
     storage_pool::AtomicSystemStoragePreference,
-    tree::{imp::packed, KeyInfo, MessageAction, pivot_key::LocalPivotKey},
+    tree::{imp::packed, pivot_key::LocalPivotKey, KeyInfo, MessageAction},
     AtomicStoragePreference, StoragePreference,
 };
 use std::{borrow::Borrow, collections::BTreeMap, iter::FromIterator};

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -360,7 +360,7 @@ where
 
     #[allow(missing_docs)]
     #[cfg(feature = "internal-api")]
-    pub fn tree_dump(&self) -> Result<impl serde::Serialize, Error>
+    pub fn tree_dump(&self) -> Result<NodeInfo, Error>
     where
         X::ObjectRef: HasStoragePreference,
     {
@@ -566,4 +566,4 @@ mod packed;
 mod range;
 mod split;
 
-pub use self::{node::Node, range::RangeIterator};
+pub use self::{node::{Node, NodeInfo}, range::RangeIterator};

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -243,7 +243,10 @@ where
         Ok(self.dml.get(&mut np_ref.write())?)
     }
 
-    fn get_node_pivot<K: Borrow<[u8]>>(&self, pivot: K) -> Result<Option<X::CacheValueRef>, TreeError> {
+    pub(crate) fn get_node_pivot<K: Borrow<[u8]>>(
+        &self,
+        pivot: K,
+    ) -> Result<Option<X::CacheValueRef>, Error> {
         let pivot = pivot.borrow();
         let mut node = self.get_root_node()?;
         Ok(loop {
@@ -281,7 +284,7 @@ where
         self.get_mut_node_mut(np_ref.get_mut())
     }
 
-    fn get_mut_node_pivot<K: Borrow<[u8]>>(
+    pub(crate) fn get_mut_node_pivot<K: Borrow<[u8]>>(
         &self,
         pivot: K,
     ) -> Result<Option<X::CacheValueRefMut>, TreeError> {

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -283,10 +283,7 @@ where
         self.dml.try_get_mut(np_ref.get_mut())
     }
 
-    fn get_mut_node_mut(
-        &self,
-        np_ref: &mut X::ObjectRef,
-    ) -> Result<X::CacheValueRefMut, Error> {
+    fn get_mut_node_mut(&self, np_ref: &mut X::ObjectRef) -> Result<X::CacheValueRefMut, Error> {
         if let Some(node) = self.dml.try_get_mut(np_ref) {
             return Ok(node);
         }
@@ -566,4 +563,7 @@ mod packed;
 mod range;
 mod split;
 
-pub use self::{node::{Node, NodeInfo}, range::RangeIterator};
+pub use self::{
+    node::{Node, NodeInfo},
+    range::RangeIterator,
+};

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -252,12 +252,9 @@ where
         let mut node = self.get_root_node()?;
         Ok(loop {
             let next_node = match node.pivot_get(pivot) {
-                Some(PivotGetResult::Target(np)) => {
-                    break Some(self.get_node(np)?)
-                },
-                Some(PivotGetResult::NextNode(np)) => {
-                    self.get_node(np)?
-                },
+                Some(PivotGetResult::Target(Some(np))) => break Some(self.get_node(np)?),
+                Some(PivotGetResult::Target(None)) => break Some(node),
+                Some(PivotGetResult::NextNode(np)) => self.get_node(np)?,
                 None => break None,
             };
             node = next_node;
@@ -272,7 +269,8 @@ where
         let mut node = self.get_mut_root_node()?;
         Ok(loop {
             let next_node = match node.pivot_get_mut(pivot) {
-                Some(PivotGetMutResult::Target(np)) => break Some(self.get_mut_node_mut(np)?),
+                Some(PivotGetMutResult::Target(Some(np))) => break Some(self.get_mut_node_mut(np)?),
+                Some(PivotGetMutResult::Target(None)) => break Some(node),
                 Some(PivotGetMutResult::NextNode(np)) => self.get_mut_node_mut(np)?,
                 None => break None,
             };

--- a/betree/src/tree/imp/mod.rs
+++ b/betree/src/tree/imp/mod.rs
@@ -138,7 +138,7 @@ where
         storage_preference: StoragePreference,
     ) -> Self {
         Tree::new(
-            X::ref_from_ptr(root_node_ptr),
+            X::root_ref_from_ptr(root_node_ptr),
             tree_id,
             msg_action,
             dml,

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -300,12 +300,12 @@ pub(super) enum ApplyResult<'a, N: 'a> {
 }
 
 pub(super) enum PivotGetResult<'a, N: 'a> {
-    Target(&'a RwLock<N>),
+    Target(Option<&'a RwLock<N>>),
     NextNode(&'a RwLock<N>),
 }
 
 pub(super) enum PivotGetMutResult<'a, N: 'a> {
-    Target(&'a mut N),
+    Target(Option<&'a mut N>),
     NextNode(&'a mut N),
 }
 
@@ -364,19 +364,23 @@ impl<N: HasStoragePreference> Node<N> {
         }
     }
 
-    pub(super) fn pivot_get(&self, pivot: &PivotKey) -> Option<PivotGetResult<N>> {
+    pub(super) fn pivot_get(&self, pk: &PivotKey) -> Option<PivotGetResult<N>> {
+        if pk.is_root() {
+            return Some(PivotGetResult::Target(None))
+        }
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
-            Internal(ref internal) => {
-                Some(internal.pivot_get(pivot))
-            }
+            Internal(ref internal) => Some(internal.pivot_get(pk)),
         }
     }
 
-    pub(super) fn pivot_get_mut(&mut self, pivot: &PivotKey) -> Option<PivotGetMutResult<N>> {
+    pub(super) fn pivot_get_mut(&mut self, pk: &PivotKey) -> Option<PivotGetMutResult<N>> {
+        if pk.is_root() {
+            return Some(PivotGetMutResult::Target(None))
+        }
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
-            Internal(ref mut internal) => Some(internal.pivot_get_mut(pivot)),
+            Internal(ref mut internal) => Some(internal.pivot_get_mut(pk)),
         }
     }
 }

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -6,7 +6,7 @@ use super::{
     leaf::LeafNode,
     packed::PackedMap,
     FillUpResult, KeyInfo, MAX_INTERNAL_NODE_SIZE, MAX_LEAF_NODE_SIZE, MIN_FANOUT, MIN_FLUSH_SIZE,
-    MIN_LEAF_NODE_SIZE,
+    MIN_LEAF_NODE_SIZE, PivotKey,
 };
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
@@ -364,7 +364,7 @@ impl<N: HasStoragePreference> Node<N> {
         }
     }
 
-    pub(super) fn pivot_get(&self, pivot: &[u8]) -> Option<PivotGetResult<N>> {
+    pub(super) fn pivot_get(&self, pivot: &PivotKey) -> Option<PivotGetResult<N>> {
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
             Internal(ref internal) => {
@@ -373,7 +373,7 @@ impl<N: HasStoragePreference> Node<N> {
         }
     }
 
-    pub(super) fn pivot_get_mut(&mut self, pivot: &[u8]) -> Option<PivotGetMutResult<N>> {
+    pub(super) fn pivot_get_mut(&mut self, pivot: &PivotKey) -> Option<PivotGetMutResult<N>> {
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
             Internal(ref mut internal) => Some(internal.pivot_get_mut(pivot)),

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -299,9 +299,9 @@ pub(super) enum ApplyResult<'a, N: 'a> {
     NextNode(&'a mut N),
 }
 
-pub(super) enum ProbeResult<'a, N: 'a> {
-    Leaf,
-    NextNode(&'a RwLock<N>),
+pub(super) enum PivotGetResult<N> {
+    Target(N),
+    NextNode(N),
 }
 
 pub(super) enum GetRangeResult<'a, T, N: 'a> {
@@ -355,6 +355,18 @@ impl<N: HasStoragePreference> Node<N> {
                     prefetch_option,
                     np,
                 }
+            }
+        }
+    }
+
+    pub(super) fn pivot_get(
+        &self,
+        pivot: &[u8],
+    ) -> Option<PivotGetResult<&RwLock<N>>> {
+        match self.0 {
+            PackedLeaf(_) | Leaf(_) => None,
+            Internal(ref internal) => {
+                Some(internal.pivot_get(pivot))
             }
         }
     }

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -5,16 +5,17 @@ use super::{
     internal::{InternalNode, TakeChildBuffer},
     leaf::LeafNode,
     packed::PackedMap,
-    FillUpResult, KeyInfo, MAX_INTERNAL_NODE_SIZE, MAX_LEAF_NODE_SIZE, MIN_FANOUT, MIN_FLUSH_SIZE,
-    MIN_LEAF_NODE_SIZE, PivotKey,
+    FillUpResult, KeyInfo, PivotKey, MAX_INTERNAL_NODE_SIZE, MAX_LEAF_NODE_SIZE, MIN_FANOUT,
+    MIN_FLUSH_SIZE, MIN_LEAF_NODE_SIZE,
 };
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::{Dml, HasStoragePreference, Object, ObjectReference},
+    database::DatasetId,
     size::{Size, SizeMut, StaticSize},
     storage_pool::DiskOffset,
-    tree::{MessageAction, pivot_key::LocalPivotKey},
-    StoragePreference, database::DatasetId,
+    tree::{pivot_key::LocalPivotKey, MessageAction},
+    StoragePreference,
 };
 use bincode::{deserialize, serialize_into};
 use parking_lot::RwLock;
@@ -280,8 +281,14 @@ impl<N: ObjectReference + StaticSize + HasStoragePreference> Node<N> {
         };
         debug!("Root split pivot key: {:?}", pivot_key);
         *self = Node(Internal(InternalNode::new(
-            ChildBuffer::new(allocate_obj(left_sibling, LocalPivotKey::LeftOuter(pivot_key.clone()))),
-            ChildBuffer::new(allocate_obj(right_sibling, LocalPivotKey::Right(pivot_key.clone()))),
+            ChildBuffer::new(allocate_obj(
+                left_sibling,
+                LocalPivotKey::LeftOuter(pivot_key.clone()),
+            )),
+            ChildBuffer::new(allocate_obj(
+                right_sibling,
+                LocalPivotKey::Right(pivot_key.clone()),
+            )),
             pivot_key,
             cur_level + 1,
         )));
@@ -367,7 +374,7 @@ impl<N: HasStoragePreference> Node<N> {
 
     pub(super) fn pivot_get(&self, pk: &PivotKey) -> Option<PivotGetResult<N>> {
         if pk.is_root() {
-            return Some(PivotGetResult::Target(None))
+            return Some(PivotGetResult::Target(None));
         }
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
@@ -377,7 +384,7 @@ impl<N: HasStoragePreference> Node<N> {
 
     pub(super) fn pivot_get_mut(&mut self, pk: &PivotKey) -> Option<PivotGetMutResult<N>> {
         if pk.is_root() {
-            return Some(PivotGetMutResult::Target(None))
+            return Some(PivotGetMutResult::Target(None));
         }
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -551,8 +551,8 @@ pub struct ChildInfo {
     from: Option<ByteString>,
     to: Option<ByteString>,
     storage: StoragePreference,
-    pivot_key: PivotKey,
-    child: NodeInfo,
+    pub pivot_key: PivotKey,
+    pub child: NodeInfo,
 }
 
 #[derive(serde::Serialize)]

--- a/betree/src/tree/imp/node.rs
+++ b/betree/src/tree/imp/node.rs
@@ -299,9 +299,14 @@ pub(super) enum ApplyResult<'a, N: 'a> {
     NextNode(&'a mut N),
 }
 
-pub(super) enum PivotGetResult<N> {
-    Target(N),
-    NextNode(N),
+pub(super) enum PivotGetResult<'a, N: 'a> {
+    Target(&'a RwLock<N>),
+    NextNode(&'a RwLock<N>),
+}
+
+pub(super) enum PivotGetMutResult<'a, N: 'a> {
+    Target(&'a mut N),
+    NextNode(&'a mut N),
 }
 
 pub(super) enum GetRangeResult<'a, T, N: 'a> {
@@ -359,15 +364,19 @@ impl<N: HasStoragePreference> Node<N> {
         }
     }
 
-    pub(super) fn pivot_get(
-        &self,
-        pivot: &[u8],
-    ) -> Option<PivotGetResult<&RwLock<N>>> {
+    pub(super) fn pivot_get(&self, pivot: &[u8]) -> Option<PivotGetResult<N>> {
         match self.0 {
             PackedLeaf(_) | Leaf(_) => None,
             Internal(ref internal) => {
                 Some(internal.pivot_get(pivot))
             }
+        }
+    }
+
+    pub(super) fn pivot_get_mut(&mut self, pivot: &[u8]) -> Option<PivotGetMutResult<N>> {
+        match self.0 {
+            PackedLeaf(_) | Leaf(_) => None,
+            Internal(ref mut internal) => Some(internal.pivot_get_mut(pivot)),
         }
     }
 }

--- a/betree/src/tree/imp/range.rs
+++ b/betree/src/tree/imp/range.rs
@@ -30,7 +30,7 @@ enum Bounded<T> {
 /// The iterator performs asynchronous prefetching to allow for a better
 /// utilization of underlying resources. It is advised to use [RangeIterator]
 /// and methods utilizing it in almost all cases.
-pub struct RangeIterator<X: Dml, M, I: Borrow<Inner<X::ObjectRef, X::Info, M>>> {
+pub struct RangeIterator<X: Dml, M, I: Borrow<Inner<X::ObjectRef, M>>> {
     buffer: VecDeque<(Key, (KeyInfo, Value))>,
     min_key: Bounded<Vec<u8>>,
     /// Always inclusive
@@ -45,7 +45,7 @@ where
     X: Dml<Object = Node<R>, ObjectRef = R>,
     R: ObjectReference<ObjectPointer = X::ObjectPointer> + HasStoragePreference,
     M: MessageAction,
-    I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
+    I: Borrow<Inner<X::ObjectRef, M>>,
 {
     type Item = Result<(Key, Value), Error>;
 
@@ -68,7 +68,7 @@ where
     X: Dml<Object = Node<R>, ObjectRef = R>,
     R: ObjectReference<ObjectPointer = X::ObjectPointer> + HasStoragePreference,
     M: MessageAction,
-    I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
+    I: Borrow<Inner<X::ObjectRef, M>>,
 {
     pub(super) fn new<K, T>(range: T, tree: Tree<X, M, I>) -> Self
     where
@@ -162,7 +162,7 @@ where
     X: Dml<Object = Node<R>, ObjectRef = R>,
     R: ObjectReference<ObjectPointer = X::ObjectPointer> + HasStoragePreference,
     M: MessageAction,
-    I: Borrow<Inner<X::ObjectRef, X::Info, M>>,
+    I: Borrow<Inner<X::ObjectRef, M>>,
 {
     fn leaf_range_query(
         &self,

--- a/betree/src/tree/imp/split.rs
+++ b/betree/src/tree/imp/split.rs
@@ -25,7 +25,7 @@ where
             root_node.size(),
             root_node.actual_size()
         );
-        let size_delta = root_node.split_root_mut(self.tree_id(), |node, pk| {
+        let size_delta = root_node.split_root_mut(|node, pk| {
             debug!(
                 "Root split child: {}, {:?}, {}, {:?}",
                 node.kind(),

--- a/betree/src/tree/imp/split.rs
+++ b/betree/src/tree/imp/split.rs
@@ -33,7 +33,8 @@ where
                 node.size(),
                 node.actual_size()
             );
-            self.dml.insert(node, self.tree_id(), pk.to_global(self.tree_id()))
+            self.dml
+                .insert(node, self.tree_id(), pk.to_global(self.tree_id()))
         });
         info!("Root split done. {}, {}", root_node.size(), size_delta);
         debug_assert!(before as isize + size_delta == root_node.size() as isize);

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -6,6 +6,7 @@ mod errors;
 mod imp;
 mod layer;
 mod message_action;
+mod pivot_key;
 
 use crate::cow_bytes::{CowBytes, SlicedCowBytes};
 
@@ -14,6 +15,7 @@ pub use self::{
     imp::{Inner, Node, Tree},
     layer::TreeLayer,
     message_action::MessageAction,
+    pivot_key::PivotKey,
 };
 
 pub use self::errors::Error;

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
 };
 
 #[cfg(not(feature = "internal-api"))]
-pub(crate) use self::{pivot_key::PivotKey, imp::NodeInfo};
+pub(crate) use self::{imp::NodeInfo, pivot_key::PivotKey};
 
 #[cfg(feature = "internal-api")]
 pub use self::{imp::NodeInfo, pivot_key::PivotKey};
@@ -27,4 +27,4 @@ type Key = CowBytes;
 type Value = SlicedCowBytes;
 
 use self::imp::KeyInfo;
-pub(crate) use self::{imp::MAX_MESSAGE_SIZE, layer::ErasedTreeSync, errors::Error};
+pub(crate) use self::{errors::Error, imp::MAX_MESSAGE_SIZE, layer::ErasedTreeSync};

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
 };
 
 #[cfg(not(feature = "internal-api"))]
-pub(crate) use self::pivot_key::PivotKey;
+pub(crate) use self::{pivot_key::PivotKey, imp::NodeInfo};
 
 #[cfg(feature = "internal-api")]
 pub use self::{imp::NodeInfo, pivot_key::PivotKey};
@@ -27,4 +27,4 @@ type Key = CowBytes;
 type Value = SlicedCowBytes;
 
 use self::imp::KeyInfo;
-pub(crate) use self::{imp::MAX_MESSAGE_SIZE, layer::ErasedTreeSync};
+pub(crate) use self::{imp::MAX_MESSAGE_SIZE, layer::ErasedTreeSync, errors::Error};

--- a/betree/src/tree/mod.rs
+++ b/betree/src/tree/mod.rs
@@ -15,10 +15,13 @@ pub use self::{
     imp::{Inner, Node, Tree},
     layer::TreeLayer,
     message_action::MessageAction,
-    pivot_key::PivotKey,
 };
 
-pub use self::errors::Error;
+#[cfg(not(feature = "internal-api"))]
+pub(crate) use self::pivot_key::PivotKey;
+
+#[cfg(feature = "internal-api")]
+pub use self::{imp::NodeInfo, pivot_key::PivotKey};
 
 type Key = CowBytes;
 type Value = SlicedCowBytes;

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -1,10 +1,7 @@
 //! A node identification key.
 //!
 //! See [PivotKey] for more documentation.
-use crate::{
-    cow_bytes::CowBytes,
-    database::DatasetId,
-};
+use crate::{cow_bytes::CowBytes, database::DatasetId};
 
 /// An identifier for an arbitrary node.
 ///
@@ -50,7 +47,7 @@ impl PivotKey {
     pub fn bytes(&self) -> Option<CowBytes> {
         match self {
             // Cheap CowBytes clone
-            Self::LeftOuter(p, _) | Self::Right(p,_) => Some(p.clone()),
+            Self::LeftOuter(p, _) | Self::Right(p, _) => Some(p.clone()),
             Self::Root(_) => None,
         }
     }
@@ -88,7 +85,7 @@ impl PivotKey {
 pub enum LocalPivotKey {
     LeftOuter(CowBytes),
     Right(CowBytes),
-    Root()
+    Root(),
 }
 
 impl LocalPivotKey {

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -29,9 +29,6 @@ use crate::{
 ///     │       │       │       │
 ///     ▼       ▼       ▼       ▼
 /// ```
-///
-/// TODO: The key is not unique atm, multiple keys can point to same node, but
-/// this relation is atleast surjective.
 #[derive(Hash, Clone, Debug, PartialEq, Eq)]
 pub enum PivotKey {
     LeftOuter(CowBytes, DatasetId),

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -1,6 +1,8 @@
 //! A node identification key.
 //!
 //! See [PivotKey] for more documentation.
+use serde::Serialize;
+
 use crate::{cow_bytes::CowBytes, database::DatasetId};
 
 /// An identifier for an arbitrary node.
@@ -26,7 +28,7 @@ use crate::{cow_bytes::CowBytes, database::DatasetId};
 ///     │       │       │       │
 ///     ▼       ▼       ▼       ▼
 /// ```
-#[derive(Hash, Clone, Debug, PartialEq, Eq)]
+#[derive(Hash, Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum PivotKey {
     LeftOuter(CowBytes, DatasetId),
     Right(CowBytes, DatasetId),
@@ -82,6 +84,7 @@ impl PivotKey {
 ///
 /// This enum is useful to transport information from node local operations to
 /// the tree layer to avoid passing around [DatasetId]s continuously.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum LocalPivotKey {
     LeftOuter(CowBytes),
     Right(CowBytes),

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -22,9 +22,9 @@ use crate::{
 ///
 ///         p1      p2      p3
 /// ┌───────┬───────┬───────┬───────┐
-/// │       │       │       │       │
-/// │  Left │ Right │ Right │ Right │
-/// │  (p1) │ (p1)  │ (p2)  │ (p3)  │
+/// │ Left  │       │       │       │
+/// │ Outer │ Right │ Right │ Right │
+/// │ (p1)  │ (p1)  │ (p2)  │ (p3)  │
 /// └───┬───┴───┬───┴───┬───┴───┬───┘
 ///     │       │       │       │
 ///     ▼       ▼       ▼       ▼
@@ -34,7 +34,7 @@ use crate::{
 /// this relation is atleast surjective.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PivotKey {
-    Left(CowBytes, DatasetId),
+    LeftOuter(CowBytes, DatasetId),
     Right(CowBytes, DatasetId),
     Root(DatasetId),
 }
@@ -43,7 +43,7 @@ impl PivotKey {
     /// Get the dataset id of this node key.
     pub fn d_id(&self) -> DatasetId {
         match self {
-            Self::Left(_, d_id) | Self::Right(_, d_id) | Self::Root(d_id) => *d_id,
+            Self::LeftOuter(_, d_id) | Self::Right(_, d_id) | Self::Root(d_id) => *d_id,
         }
     }
 
@@ -53,7 +53,7 @@ impl PivotKey {
     pub fn bytes(&self) -> Option<CowBytes> {
         match self {
             // Cheap CowBytes clone
-            Self::Left(p, _) | Self::Right(p,_) => Some(p.clone()),
+            Self::LeftOuter(p, _) | Self::Right(p,_) => Some(p.clone()),
             Self::Root(_) => None,
         }
     }
@@ -68,7 +68,7 @@ impl PivotKey {
     /// See [PivotKey] for a more detailed instruction.
     pub fn is_left(&self) -> bool {
         match self {
-            Self::Left(..) => true,
+            Self::LeftOuter(..) => true,
             _ => false,
         }
     }

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -32,6 +32,7 @@ use crate::{
 ///
 /// TODO: The key is not unique atm, multiple keys can point to same node, but
 /// this relation is atleast surjective.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PivotKey {
     Left(CowBytes, DatasetId),
     Right(CowBytes, DatasetId),

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -1,0 +1,84 @@
+//! A node identification key.
+//!
+//! See [PivotKey] for more documentation.
+use crate::{
+    cow_bytes::CowBytes,
+    database::DatasetId,
+};
+
+/// An identifier for an arbitrary node.
+///
+/// The access is part direction, part position of the relation from the
+/// *parent* node. For the root this position is arbitrary and carries no pivot.
+/// The dataset id determines the identity of the tree in which the given bytes
+/// can be found. This makes the [PivotKey] globally unique and suitable to
+/// accesss and identify certain nodes within a tree.
+///
+/// Furthermore, a key does not have to exist as keys can be changed or deleted
+/// over the lifetime of a tree; take care to deal with missing information.
+///
+/// ```text
+/// px - Pivot Element
+///
+///         p1      p2      p3
+/// ┌───────┬───────┬───────┬───────┐
+/// │       │       │       │       │
+/// │  Left │ Right │ Right │ Right │
+/// │  (p1) │ (p1)  │ (p2)  │ (p3)  │
+/// └───┬───┴───┬───┴───┬───┴───┬───┘
+///     │       │       │       │
+///     ▼       ▼       ▼       ▼
+/// ```
+///
+/// TODO: The key is not unique atm, multiple keys can point to same node, but
+/// this relation is atleast surjective.
+pub enum PivotKey {
+    Left(CowBytes, DatasetId),
+    Right(CowBytes, DatasetId),
+    Root(DatasetId),
+}
+
+impl PivotKey {
+    /// Get the dataset id of this node key.
+    pub fn d_id(&self) -> DatasetId {
+        match self {
+            Self::Left(_, d_id) | Self::Right(_, d_id) | Self::Root(d_id) => *d_id,
+        }
+    }
+
+    /// Get the pivot bytes of this node key.
+    ///
+    /// If the return value is none, the indexed node is the *root* of the tree.
+    pub fn bytes(&self) -> Option<CowBytes> {
+        match self {
+            // Cheap CowBytes clone
+            Self::Left(p, _) | Self::Right(p,_) => Some(p.clone()),
+            Self::Root(_) => None,
+        }
+    }
+
+    /// Wether or not the key indexes a root node.
+    pub fn is_root(&self) -> bool {
+        self.bytes().is_none()
+    }
+
+    /// Wether or not the direction from the pivot is left.
+    ///
+    /// See [PivotKey] for a more detailed instruction.
+    pub fn is_left(&self) -> bool {
+        match self {
+            Self::Left(..) => true,
+            _ => false,
+        }
+    }
+
+    /// Wether or not the direction from the pivot is right.
+    ///
+    /// See [PivotKey] for a more detailed instruction.
+    pub fn is_right(&self) -> bool {
+        match self {
+            Self::Right(..) => true,
+            _ => false,
+        }
+    }
+}

--- a/betree/src/tree/pivot_key.rs
+++ b/betree/src/tree/pivot_key.rs
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// TODO: The key is not unique atm, multiple keys can point to same node, but
 /// this relation is atleast surjective.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Hash, Clone, Debug, PartialEq, Eq)]
 pub enum PivotKey {
     LeftOuter(CowBytes, DatasetId),
     Right(CowBytes, DatasetId),
@@ -80,6 +80,26 @@ impl PivotKey {
         match self {
             Self::Right(..) => true,
             _ => false,
+        }
+    }
+}
+
+/// A PivotKey without indication of global tree location.
+///
+/// This enum is useful to transport information from node local operations to
+/// the tree layer to avoid passing around [DatasetId]s continuously.
+pub enum LocalPivotKey {
+    LeftOuter(CowBytes),
+    Right(CowBytes),
+    Root()
+}
+
+impl LocalPivotKey {
+    pub fn to_global(self, d_id: DatasetId) -> PivotKey {
+        match self {
+            LocalPivotKey::LeftOuter(p) => PivotKey::LeftOuter(p, d_id),
+            LocalPivotKey::Right(p) => PivotKey::Right(p, d_id),
+            LocalPivotKey::Root() => PivotKey::Root(d_id),
         }
     }
 }

--- a/betree/tests/src/configs.rs
+++ b/betree/tests/src/configs.rs
@@ -2,7 +2,7 @@ use std::sync::{Once, RwLock, RwLockWriteGuard};
 
 use betree_storage_stack::{
     database::AccessMode,
-    migration::{MigrationConfig, MigrationPolicies, LfuConfig, LfuMode},
+    migration::{LfuConfig, LfuMode, MigrationConfig, MigrationPolicies},
     storage_pool::{configuration::Vdev, LeafVdev, TierConfiguration},
     DatabaseConfiguration, StoragePoolConfiguration,
 };
@@ -14,16 +14,18 @@ pub fn access_specific_config() -> DatabaseConfiguration {
         storage: StoragePoolConfiguration {
             tiers: vec![
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory { mem: 2048 * TO_MEBIBYTE })
-                    ],
-                    preferred_access_type: betree_storage_stack::PreferredAccessType::RandomReadWrite
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
+                    preferred_access_type:
+                        betree_storage_stack::PreferredAccessType::RandomReadWrite,
                 },
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory { mem: 2048 * TO_MEBIBYTE })
-                    ],
-                    preferred_access_type: betree_storage_stack::PreferredAccessType::SequentialReadWrite
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
+                    preferred_access_type:
+                        betree_storage_stack::PreferredAccessType::SequentialReadWrite,
                 },
             ],
             ..Default::default()
@@ -50,19 +52,15 @@ fn migration_config_lfu(mode: LfuMode) -> DatabaseConfiguration {
         storage: StoragePoolConfiguration {
             tiers: vec![
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory {
-                            mem: 2048 * TO_MEBIBYTE,
-                        }),
-                    ],
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
                     ..Default::default()
                 },
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory {
-                            mem: 2048 * TO_MEBIBYTE,
-                        }),
-                    ],
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
                     ..Default::default()
                 },
             ],
@@ -88,19 +86,15 @@ pub(crate) fn migration_config_rl() -> DatabaseConfiguration {
         storage: StoragePoolConfiguration {
             tiers: vec![
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory {
-                            mem: 2048 * TO_MEBIBYTE,
-                        }),
-                    ],
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
                     ..Default::default()
                 },
                 TierConfiguration {
-                    top_level_vdevs: vec![
-                        Vdev::Leaf(LeafVdev::Memory {
-                            mem: 2048 * TO_MEBIBYTE,
-                        }),
-                    ],
+                    top_level_vdevs: vec![Vdev::Leaf(LeafVdev::Memory {
+                        mem: 2048 * TO_MEBIBYTE,
+                    })],
                     ..Default::default()
                 },
             ],

--- a/betree/tests/src/lib.rs
+++ b/betree/tests/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod configs;
 mod object_store;
+mod pivot_key;
+mod util;
 
 use betree_storage_stack::{
     compression::CompressionConfiguration,
@@ -894,7 +896,10 @@ fn migration_policy_single_node() {
 
     ds.insert(b"foobar".to_vec(), &[42; 4096]).unwrap();
     sync();
-    assert_json_snapshot!("migration_policy_single_node__before_migration", json!(ds.tree_dump().unwrap()));
+    assert_json_snapshot!(
+        "migration_policy_single_node__before_migration",
+        json!(ds.tree_dump().unwrap())
+    );
     std::thread::sleep(std::time::Duration::from_secs(1));
     ds.upsert(b"foobar".to_vec(), &[43; 1024], 1).unwrap();
     ds.upsert(b"foobar".to_vec(), &[43; 1024], 1).unwrap();
@@ -902,7 +907,10 @@ fn migration_policy_single_node() {
     ds.upsert(b"foobar".to_vec(), &[43; 1024], 1).unwrap();
     sync();
     std::thread::sleep(std::time::Duration::from_secs(1));
-    assert_json_snapshot!("migration_policy_single_node__after_migration",json!(ds.tree_dump().unwrap()));
+    assert_json_snapshot!(
+        "migration_policy_single_node__after_migration",
+        json!(ds.tree_dump().unwrap())
+    );
     sync();
 }
 
@@ -916,9 +924,13 @@ fn migration_policy_single_object() {
         os = db.open_object_store().unwrap();
         db.sync().unwrap();
     }
-    let obj = os.open_or_create_object_with_pref(b"foo", StoragePreference::FAST).unwrap().0;
+    let obj = os
+        .open_or_create_object_with_pref(b"foo", StoragePreference::FAST)
+        .unwrap()
+        .0;
     let mut buf = vec![42; 200 * TO_MEBIBYTE];
-    obj.write_at_with_pref(&buf, 0, StoragePreference::FAST).unwrap();
+    obj.write_at_with_pref(&buf, 0, StoragePreference::FAST)
+        .unwrap();
     std::thread::sleep(std::time::Duration::from_secs(2));
     shared_db.write().sync().unwrap();
     obj.read_at(&mut buf, 0).unwrap();

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -1,4 +1,4 @@
-use betree_storage_stack::{StoragePreference, Database};
+use betree_storage_stack::{Database, StoragePreference};
 
 use crate::{configs, TO_MEBIBYTE};
 
@@ -7,52 +7,62 @@ use super::test_db;
 #[test]
 // Open and close the default object store and test if the objects are preserved
 fn default_object_store_object_persists() {
-        let mut db = test_db(2, 64);
-        let os = db.open_object_store().unwrap();
-        let obj = os.open_or_create_object(b"hewo").unwrap();
-        obj.write_at(&[1,2,3], 0).unwrap();
-        obj.close().unwrap();
-        db.close_object_store(os);
-        let os = db.open_object_store().unwrap();
-        let obj = os.open_object(b"hewo").unwrap().unwrap();
-        let mut buf = vec![0; 3];
-        obj.read_at(&mut buf, 0).unwrap();
-        assert_eq!(buf, [1,2,3]);
-        let other = db.open_named_object_store(b"uwu", StoragePreference::NONE).unwrap();
-        assert!(other.open_object(b"hewo").unwrap().is_none());
+    let mut db = test_db(2, 64);
+    let os = db.open_object_store().unwrap();
+    let obj = os.open_or_create_object(b"hewo").unwrap();
+    obj.write_at(&[1, 2, 3], 0).unwrap();
+    obj.close().unwrap();
+    db.close_object_store(os);
+    let os = db.open_object_store().unwrap();
+    let obj = os.open_object(b"hewo").unwrap().unwrap();
+    let mut buf = vec![0; 3];
+    obj.read_at(&mut buf, 0).unwrap();
+    assert_eq!(buf, [1, 2, 3]);
+    let other = db
+        .open_named_object_store(b"uwu", StoragePreference::NONE)
+        .unwrap();
+    assert!(other.open_object(b"hewo").unwrap().is_none());
 }
 
 #[test]
 // Open and close the default object store and test if the objects are preserved
 fn object_store_object_persists() {
-        let mut db = test_db(2, 64);
-        let os = db.open_named_object_store(b"uwu", StoragePreference::NONE).unwrap();
-        let obj = os.open_or_create_object(b"hewo").unwrap();
-        obj.write_at(&[1,2,3], 0).unwrap();
-        obj.close().unwrap();
-        db.close_object_store(os);
-        let os = db.open_named_object_store(b"uwu", StoragePreference::NONE).unwrap();
-        let obj = os.open_object(b"hewo").unwrap().unwrap();
-        let mut buf = vec![0; 3];
-        obj.read_at(&mut buf, 0).unwrap();
-        assert_eq!(buf, [1,2,3]);
-        let other = db.open_object_store().unwrap();
-        assert!(other.open_object(b"hewo").unwrap().is_none());
+    let mut db = test_db(2, 64);
+    let os = db
+        .open_named_object_store(b"uwu", StoragePreference::NONE)
+        .unwrap();
+    let obj = os.open_or_create_object(b"hewo").unwrap();
+    obj.write_at(&[1, 2, 3], 0).unwrap();
+    obj.close().unwrap();
+    db.close_object_store(os);
+    let os = db
+        .open_named_object_store(b"uwu", StoragePreference::NONE)
+        .unwrap();
+    let obj = os.open_object(b"hewo").unwrap().unwrap();
+    let mut buf = vec![0; 3];
+    obj.read_at(&mut buf, 0).unwrap();
+    assert_eq!(buf, [1, 2, 3]);
+    let other = db.open_object_store().unwrap();
+    assert!(other.open_object(b"hewo").unwrap().is_none());
 }
 
 #[test]
 fn object_store_iter() {
-        let mut db = test_db(2, 64);
-        let os = db.open_object_store().unwrap();
-        db.close_object_store(os);
-        let os = db.open_named_object_store(b"uwu", StoragePreference::NONE).unwrap();
-        db.close_object_store(os);
-        let os = db.open_named_object_store(b"snek", StoragePreference::NONE).unwrap();
-        db.close_object_store(os);
-        let mut osl = db.iter_object_stores_pub().unwrap();
-        assert_eq!(osl.next().unwrap().unwrap().as_u64(), 1);
-        assert_eq!(osl.next().unwrap().unwrap().as_u64(), 2);
-        assert_eq!(osl.next().unwrap().unwrap().as_u64(), 3);
+    let mut db = test_db(2, 64);
+    let os = db.open_object_store().unwrap();
+    db.close_object_store(os);
+    let os = db
+        .open_named_object_store(b"uwu", StoragePreference::NONE)
+        .unwrap();
+    db.close_object_store(os);
+    let os = db
+        .open_named_object_store(b"snek", StoragePreference::NONE)
+        .unwrap();
+    db.close_object_store(os);
+    let mut osl = db.iter_object_stores_pub().unwrap();
+    assert_eq!(osl.next().unwrap().unwrap().as_u64(), 1);
+    assert_eq!(osl.next().unwrap().unwrap().as_u64(), 2);
+    assert_eq!(osl.next().unwrap().unwrap().as_u64(), 3);
 }
 
 #[test]
@@ -71,15 +81,21 @@ fn object_store_reinit_from_iterator() {
     // Test opening of multiple stores by their names.
     // Test if the default store name '0' gets skipped.
     let mut db = test_db(2, 64);
-    let os = db.open_named_object_store(b"foo", StoragePreference::NONE).unwrap();
+    let os = db
+        .open_named_object_store(b"foo", StoragePreference::NONE)
+        .unwrap();
     db.close_object_store(os);
-    let os = db.open_named_object_store(b"bar", StoragePreference::NONE).unwrap();
+    let os = db
+        .open_named_object_store(b"bar", StoragePreference::NONE)
+        .unwrap();
     db.close_object_store(os);
     let os = db.open_object_store().unwrap();
     db.close_object_store(os);
     assert!(db.iter_object_store_names().unwrap().count() == 2);
     for name in db.iter_object_store_names().unwrap() {
-        let _ = db.open_named_object_store(&name, StoragePreference::NONE).unwrap();
+        let _ = db
+            .open_named_object_store(&name, StoragePreference::NONE)
+            .unwrap();
     }
 }
 
@@ -91,12 +107,22 @@ fn object_store_access_pattern() {
     // 1 - SeqRW
     let mut db = Database::build(configs::access_specific_config()).unwrap();
     let os = db.open_object_store().unwrap();
-    let (obj, _) = os.create_object_with_access_type(b"foo", betree_storage_stack::PreferredAccessType::SequentialReadWrite).unwrap();
+    let (obj, _) = os
+        .create_object_with_access_type(
+            b"foo",
+            betree_storage_stack::PreferredAccessType::SequentialReadWrite,
+        )
+        .unwrap();
     let dat = vec![42; 32 * TO_MEBIBYTE];
-    obj.write_at(&dat[..16*TO_MEBIBYTE], 0).unwrap();
+    obj.write_at(&dat[..16 * TO_MEBIBYTE], 0).unwrap();
     db.sync().unwrap();
     assert!(db.free_space_tier()[0].free > db.free_space_tier()[1].free);
-    let (obj, _) = os.create_object_with_access_type(b"foo", betree_storage_stack::PreferredAccessType::RandomReadWrite).unwrap();
+    let (obj, _) = os
+        .create_object_with_access_type(
+            b"foo",
+            betree_storage_stack::PreferredAccessType::RandomReadWrite,
+        )
+        .unwrap();
     obj.write_at(&dat, 0).unwrap();
     db.sync().unwrap();
     assert!(db.free_space_tier()[0].free < db.free_space_tier()[1].free);

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -1,8 +1,6 @@
 use betree_storage_stack::{Database, StoragePreference};
 
-use crate::{configs, TO_MEBIBYTE};
-
-use super::test_db;
+use super::{configs, test_db, TO_MEBIBYTE};
 
 #[test]
 // Open and close the default object store and test if the objects are preserved

--- a/betree/tests/src/pivot_key.rs
+++ b/betree/tests/src/pivot_key.rs
@@ -1,0 +1,58 @@
+use super::util;
+use betree_storage_stack::{
+    data_management::HasStoragePreference,
+    tree::{NodeInfo, PivotKey},
+    Database, DatabaseConfiguration, Dataset,
+};
+use rand::{seq::IteratorRandom, RngCore};
+
+#[test]
+fn structure_is_good() {
+    let (_db, ds) = util::random_db(2, 128);
+    let dmp = ds.tree_dump().unwrap();
+    internal_node_check(&dmp)
+}
+
+#[test]
+fn get() {
+    let (_db, ds) = util::random_db(2, 128);
+    let dmp = ds.tree_dump().unwrap();
+    let pk = random_pivot_key(&dmp).clone().unwrap();
+    let _node = ds.test_get_node_pivot(&pk).unwrap().unwrap();
+}
+
+fn random_pivot_key(ni: &NodeInfo) -> Option<&PivotKey> {
+    match ni {
+        NodeInfo::Internal { children, .. } => {
+            let mut rng = rand::thread_rng();
+            Some(
+                children
+                    .iter()
+                    .flat_map(|c_buf| [Some(&c_buf.pivot_key), random_pivot_key(&c_buf.child)])
+                    .filter_map(|e| e)
+                    .choose(&mut rng)
+                    .unwrap(),
+            )
+        }
+        // Only inspect Internal nodes as they hold child buffers
+        _ => None,
+    }
+}
+
+fn internal_node_check(ni: &NodeInfo) {
+    match ni {
+        NodeInfo::Internal { children, .. } => {
+            for (idx, c_buf) in children.iter().enumerate() {
+                assert!(!c_buf.pivot_key.is_root());
+                if idx == 0 {
+                    assert!(c_buf.pivot_key.is_left());
+                } else {
+                    assert!(c_buf.pivot_key.is_right());
+                }
+                internal_node_check(&c_buf.child)
+            }
+        }
+        // Only inspect Internal nodes as they hold child buffers
+        _ => {}
+    }
+}

--- a/betree/tests/src/pivot_key.rs
+++ b/betree/tests/src/pivot_key.rs
@@ -1,10 +1,6 @@
 use super::util;
-use betree_storage_stack::{
-    data_management::HasStoragePreference,
-    tree::{NodeInfo, PivotKey},
-    Database, DatabaseConfiguration, Dataset,
-};
-use rand::{seq::IteratorRandom, RngCore};
+use betree_storage_stack::tree::{NodeInfo, PivotKey};
+use rand::seq::IteratorRandom;
 
 #[test]
 fn structure_is_good() {

--- a/betree/tests/src/snapshots/betree_tests__delete single__deleted something.snap
+++ b/betree/tests/src/snapshots/betree_tests__delete single__deleted something.snap
@@ -23,6 +23,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -35,6 +54,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -47,6 +85,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -59,6 +116,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -71,6 +147,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -83,6 +178,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 008F"
       },
@@ -95,6 +209,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00A7"
       },
@@ -107,6 +240,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00BF"
       },
@@ -119,6 +271,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00D7"
       },
@@ -131,6 +302,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00EF"
       },
@@ -143,6 +333,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00EF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              239
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0107"
       },
@@ -155,6 +364,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0107",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              7
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 011F"
       },
@@ -167,6 +395,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 011F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              31
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0137"
       },
@@ -179,6 +426,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0137",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              55
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 014F"
       },
@@ -191,6 +457,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 014F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              79
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0167"
       },
@@ -203,6 +488,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0167",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              103
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 017F"
       },
@@ -215,6 +519,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 017F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              127
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0197"
       },
@@ -227,6 +550,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0197",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              151
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01AF"
       },
@@ -239,6 +581,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01AF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              175
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01C7"
       },
@@ -251,6 +612,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01C7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              199
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01DF"
       },
@@ -263,6 +643,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01DF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              223
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01F7"
       },
@@ -275,6 +674,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01F7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              247
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 020F"
       },
@@ -287,6 +705,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 020F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              15
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0227"
       },
@@ -299,6 +736,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0227",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              39
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 023F"
       },
@@ -311,6 +767,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 023F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              63
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0257"
       },
@@ -323,6 +798,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0257",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              87
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 026F"
       },
@@ -335,6 +829,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 026F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              111
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0287"
       },
@@ -347,6 +860,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0287",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              135
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 029F"
       },
@@ -359,6 +891,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 029F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              159
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02B7"
       },
@@ -371,6 +922,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02B7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              183
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02CF"
       },
@@ -383,6 +953,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02CF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              207
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02E7"
       },
@@ -395,6 +984,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02E7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              231
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02FF"
       },
@@ -407,6 +1015,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02FF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              255
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0317"
       },
@@ -419,6 +1046,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0317",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 032F"
       },
@@ -431,6 +1077,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 032F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0347"
       },
@@ -443,6 +1108,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0347",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 035F"
       },
@@ -455,6 +1139,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 035F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0377"
       },
@@ -467,6 +1170,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0377",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 038F"
       },
@@ -479,6 +1201,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 038F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03A7"
       },
@@ -491,6 +1232,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03BF"
       },
@@ -503,6 +1263,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03D7"
       },
@@ -515,6 +1294,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__delete single__inserted something.snap
+++ b/betree/tests/src/snapshots/betree_tests__delete single__inserted something.snap
@@ -14035,6 +14035,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -14047,6 +14066,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -14059,6 +14097,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -14071,6 +14128,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -14083,6 +14159,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -14095,6 +14190,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 008F"
       },
@@ -14107,6 +14221,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00A7"
       },
@@ -14119,6 +14252,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00BF"
       },
@@ -14131,6 +14283,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00D7"
       },
@@ -14143,6 +14314,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00EF"
       },
@@ -14155,6 +14345,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00EF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              239
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0107"
       },
@@ -14167,6 +14376,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0107",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              7
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 011F"
       },
@@ -14179,6 +14407,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 011F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              31
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0137"
       },
@@ -14191,6 +14438,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0137",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              55
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 014F"
       },
@@ -14203,6 +14469,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 014F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              79
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0167"
       },
@@ -14215,6 +14500,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0167",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              103
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 017F"
       },
@@ -14227,6 +14531,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 017F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              127
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0197"
       },
@@ -14239,6 +14562,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0197",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              151
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01AF"
       },
@@ -14251,6 +14593,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01AF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              175
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01C7"
       },
@@ -14263,6 +14624,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01C7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              199
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01DF"
       },
@@ -14275,6 +14655,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01DF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              223
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01F7"
       },
@@ -14287,6 +14686,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01F7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              247
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 020F"
       },
@@ -14299,6 +14717,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 020F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              15
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0227"
       },
@@ -14311,6 +14748,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0227",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              39
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 023F"
       },
@@ -14323,6 +14779,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 023F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              63
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0257"
       },
@@ -14335,6 +14810,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0257",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              87
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 026F"
       },
@@ -14347,6 +14841,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 026F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              111
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0287"
       },
@@ -14359,6 +14872,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0287",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              135
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 029F"
       },
@@ -14371,6 +14903,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 029F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              159
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02B7"
       },
@@ -14383,6 +14934,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02B7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              183
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02CF"
       },
@@ -14395,6 +14965,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02CF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              207
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02E7"
       },
@@ -14407,6 +14996,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02E7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              231
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 02FF"
       },
@@ -14419,6 +15027,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 02FF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              2,
+              255
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0317"
       },
@@ -14431,6 +15058,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0317",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 032F"
       },
@@ -14443,6 +15089,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 032F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0347"
       },
@@ -14455,6 +15120,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0347",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 035F"
       },
@@ -14467,6 +15151,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 035F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0377"
       },
@@ -14479,6 +15182,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0377",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 038F"
       },
@@ -14491,6 +15213,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 038F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03A7"
       },
@@ -14503,6 +15244,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03BF"
       },
@@ -14515,6 +15275,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03D7"
       },
@@ -14527,6 +15306,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__downgrade__fast pref.snap
+++ b/betree/tests/src/snapshots/betree_tests__downgrade__fast pref.snap
@@ -1877,6 +1877,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 1,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -1889,6 +1908,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 1,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -1901,6 +1939,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 1,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -1913,6 +1970,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 1,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -1925,6 +2001,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 1,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -1937,6 +2032,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__downgrade__fastest pref.snap
+++ b/betree/tests/src/snapshots/betree_tests__downgrade__fastest pref.snap
@@ -1779,6 +1779,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -1791,6 +1810,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -1803,6 +1841,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -1815,6 +1872,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -1827,6 +1903,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__insert single__deleted foo.snap
+++ b/betree/tests/src/snapshots/betree_tests__insert single__deleted foo.snap
@@ -23,6 +23,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -35,6 +54,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -47,6 +85,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -59,6 +116,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -71,6 +147,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -83,6 +178,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 008F"
       },
@@ -95,6 +209,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00A7"
       },
@@ -107,6 +240,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00BF"
       },
@@ -119,6 +271,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00D7"
       },
@@ -131,6 +302,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00EF"
       },
@@ -143,6 +333,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00EF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              239
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__insert single__inserted bar.snap
+++ b/betree/tests/src/snapshots/betree_tests__insert single__inserted bar.snap
@@ -2661,6 +2661,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -2673,6 +2692,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -2685,6 +2723,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -2697,6 +2754,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -2709,6 +2785,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -2721,6 +2816,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 008F"
       },
@@ -2733,6 +2847,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00A7"
       },
@@ -2745,6 +2878,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00BF"
       },
@@ -2757,6 +2909,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00D7"
       },
@@ -2769,6 +2940,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00EF"
       },
@@ -2781,6 +2971,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00EF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              239
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 0017"
       },
@@ -2793,6 +3002,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 002F"
       },
@@ -2805,6 +3033,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 0047"
       },
@@ -2817,6 +3064,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 005F"
       },
@@ -2829,6 +3095,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 0077"
       },
@@ -2841,6 +3126,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 008F"
       },
@@ -2853,6 +3157,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0001 0000 00A7"
       },
@@ -2865,6 +3188,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0001 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__insert single__inserted foo.snap
+++ b/betree/tests/src/snapshots/betree_tests__insert single__inserted foo.snap
@@ -1779,6 +1779,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -1791,6 +1810,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -1803,6 +1841,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -1815,6 +1872,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -1827,6 +1903,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__insert single__rewrote foo, but larger.snap
+++ b/betree/tests/src/snapshots/betree_tests__insert single__rewrote foo, but larger.snap
@@ -3529,6 +3529,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0017"
       },
@@ -3541,6 +3560,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0017",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              23
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 002F"
       },
@@ -3553,6 +3591,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 002F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0047"
       },
@@ -3565,6 +3622,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0047",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              71
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 005F"
       },
@@ -3577,6 +3653,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 005F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              95
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0077"
       },
@@ -3589,6 +3684,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0077",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              119
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 008F"
       },
@@ -3601,6 +3715,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 008F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              143
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00A7"
       },
@@ -3613,6 +3746,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00A7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              167
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00BF"
       },
@@ -3625,6 +3777,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00BF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              191
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00D7"
       },
@@ -3637,6 +3808,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00D7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              215
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 00EF"
       },
@@ -3649,6 +3839,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 00EF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              239
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__migration_policy_single_node__after_migration.snap
+++ b/betree/tests/src/snapshots/betree_tests__migration_policy_single_node__after_migration.snap
@@ -5,7 +5,7 @@ expression: json!(ds.tree_dump().unwrap())
 {
   "entry_count": 1,
   "level": 0,
-  "storage": 254,
-  "system_storage": 254,
+  "storage": 0,
+  "system_storage": 0,
   "type": "leaf"
 }

--- a/betree/tests/src/snapshots/betree_tests__migration_policy_single_node__after_migration.snap
+++ b/betree/tests/src/snapshots/betree_tests__migration_policy_single_node__after_migration.snap
@@ -5,7 +5,7 @@ expression: json!(ds.tree_dump().unwrap())
 {
   "entry_count": 1,
   "level": 0,
-  "storage": 0,
-  "system_storage": 0,
+  "storage": 254,
+  "system_storage": 254,
   "type": "leaf"
 }

--- a/betree/tests/src/snapshots/betree_tests__sparse__sparse write 1.snap
+++ b/betree/tests/src/snapshots/betree_tests__sparse__sparse write 1.snap
@@ -2829,6 +2829,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              67
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0143"
       },
@@ -2841,6 +2860,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0143",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              67
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 015B"
       },
@@ -2853,6 +2891,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 015B",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              91
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0173"
       },
@@ -2865,6 +2922,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0173",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              115
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 018B"
       },
@@ -2877,6 +2953,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 018B",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              139
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01A3"
       },
@@ -2889,6 +2984,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01A3",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              163
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01BB"
       },
@@ -2901,6 +3015,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01BB",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              187
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01D3"
       },
@@ -2913,6 +3046,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01D3",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              211
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01EB"
       },
@@ -2925,6 +3077,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01EB",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              235
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/snapshots/betree_tests__sparse__sparse write 2.snap
+++ b/betree/tests/src/snapshots/betree_tests__sparse__sparse write 2.snap
@@ -7029,6 +7029,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": null,
+        "pivot_key": {
+          "LeftOuter": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              67
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0143"
       },
@@ -7041,6 +7060,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0143",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              67
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 015B"
       },
@@ -7053,6 +7091,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 015B",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              91
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0173"
       },
@@ -7065,6 +7122,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0173",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              115
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 018B"
       },
@@ -7077,6 +7153,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 018B",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              139
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01A3"
       },
@@ -7089,6 +7184,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01A3",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              163
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01BB"
       },
@@ -7101,6 +7215,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01BB",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              187
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01D3"
       },
@@ -7113,6 +7246,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01D3",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              211
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 01EB"
       },
@@ -7125,6 +7277,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 01EB",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              235
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 032F"
       },
@@ -7137,6 +7308,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 032F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              47
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0337"
       },
@@ -7149,6 +7339,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0337",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              55
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 034F"
       },
@@ -7161,6 +7370,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 034F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              79
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0367"
       },
@@ -7173,6 +7401,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0367",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              103
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 037F"
       },
@@ -7185,6 +7432,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 037F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              127
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0397"
       },
@@ -7197,6 +7463,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0397",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              151
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03AF"
       },
@@ -7209,6 +7494,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03AF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              175
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03C7"
       },
@@ -7221,6 +7525,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03C7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              199
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03DF"
       },
@@ -7233,6 +7556,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03DF",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              223
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 03F7"
       },
@@ -7245,6 +7587,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 03F7",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              247
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 040F"
       },
@@ -7257,6 +7618,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 040F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              4,
+              15
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 0427"
       },
@@ -7269,6 +7649,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 0427",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              4,
+              39
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": "0000 0000 0000 0000 0000 043F"
       },
@@ -7281,6 +7680,25 @@ expression: "json!({\n        \"shape/data\" :\n        self.object_store.data_t
           "type": "leaf"
         },
         "from": "0000 0000 0000 0000 0000 043F",
+        "pivot_key": {
+          "Right": [
+            [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              4,
+              63
+            ],
+            1
+          ]
+        },
         "storage": 0,
         "to": null
       }

--- a/betree/tests/src/util.rs
+++ b/betree/tests/src/util.rs
@@ -1,5 +1,5 @@
 use super::test_db;
-use betree_storage_stack::{Database, DatabaseConfiguration, Dataset};
+use betree_storage_stack::{Database, Dataset};
 use rand::RngCore;
 
 pub fn random_db(tier: u32, mb_per_tier: u32) -> (Database, Dataset) {

--- a/betree/tests/src/util.rs
+++ b/betree/tests/src/util.rs
@@ -6,8 +6,8 @@ pub fn random_db(
     tier: u32,
     mb_per_tier: u32,
 ) -> (
-    Database<DatabaseConfiguration>,
-    Dataset<DatabaseConfiguration>,
+    Database,
+    Dataset,
 ) {
     let mut db = test_db(tier, mb_per_tier);
     let ds = db.open_or_create_dataset(b"hey").unwrap();

--- a/betree/tests/src/util.rs
+++ b/betree/tests/src/util.rs
@@ -2,13 +2,7 @@ use super::test_db;
 use betree_storage_stack::{Database, DatabaseConfiguration, Dataset};
 use rand::RngCore;
 
-pub fn random_db(
-    tier: u32,
-    mb_per_tier: u32,
-) -> (
-    Database,
-    Dataset,
-) {
+pub fn random_db(tier: u32, mb_per_tier: u32) -> (Database, Dataset) {
     let mut db = test_db(tier, mb_per_tier);
     let ds = db.open_or_create_dataset(b"hey").unwrap();
     let mut key = vec![0u8; 64];

--- a/betree/tests/src/util.rs
+++ b/betree/tests/src/util.rs
@@ -1,0 +1,24 @@
+use super::test_db;
+use betree_storage_stack::{Database, DatabaseConfiguration, Dataset};
+use rand::RngCore;
+
+pub fn random_db(
+    tier: u32,
+    mb_per_tier: u32,
+) -> (
+    Database<DatabaseConfiguration>,
+    Dataset<DatabaseConfiguration>,
+) {
+    let mut db = test_db(tier, mb_per_tier);
+    let ds = db.open_or_create_dataset(b"hey").unwrap();
+    let mut key = vec![0u8; 64];
+    let mut val = vec![0u8; 4096];
+    let mut rng = rand::thread_rng();
+    for _ in 0..20000 {
+        rng.fill_bytes(&mut key);
+        rng.fill_bytes(&mut val);
+        ds.insert(key.clone(), val.as_slice()).unwrap();
+    }
+    db.sync().unwrap();
+    (db, ds)
+}


### PR DESCRIPTION
> Dependencies: #29 #32 

This PR adds PivotKeys.

Changes are described in #29, basic tests have been implemented and the LFU migration policy has been modified to use these new keys. Therefore, deprecating the use of `DiskOffsets` in the node identification process.