### PR TITLE
Feature: Persist disk granular space accounting

### DIFF
--- a/bectl/src/main.rs
+++ b/bectl/src/main.rs
@@ -9,7 +9,7 @@ use betree_storage_stack::{
     cow_bytes::CowBytes,
     database::{Database, DatabaseConfiguration, Superblock},
     tree::{DefaultMessageAction, TreeLayer},
-    StoragePreference,
+    StoragePreference, storage_pool::DiskOffset,
 };
 use chrono::{DateTime, Utc};
 use figment::providers::Format;
@@ -207,7 +207,7 @@ fn bectl_main() -> Result<(), Error> {
                 let dmu = root.dmu();
                 let handler = dmu.handler();
 
-                let space = handler.get_free_space(0,0);
+                let space = handler.free_space_disk(DiskOffset::construct_disk_id(0, 0));
                 println!("{:?}", space);
             }
 

--- a/betree/src/data_management/dmu.rs
+++ b/betree/src/data_management/dmu.rs
@@ -491,7 +491,7 @@ where
 
             if self
                 .handler
-                .get_free_space_tier(class)
+                .free_space_tier(class)
                 .expect("Has to exist")
                 .free
                 .as_u64()
@@ -500,7 +500,7 @@ where
                 warn!(
                     "Storage tier {class} does not have enough space remaining. {} blocks of {}",
                     self.handler
-                        .get_free_space_tier(class)
+                        .free_space_tier(class)
                         .unwrap()
                         .free
                         .as_u64(),
@@ -518,7 +518,7 @@ where
                         class,
                         disk_id,
                         self.handler
-                            .get_free_space(DiskOffset::construct_disk_id(class, disk_id))
+                            .free_space_disk(DiskOffset::construct_disk_id(class, disk_id))
                             .expect("We can be sure that this disk id exists.")
                             .free,
                     )
@@ -554,7 +554,7 @@ where
                         warn!("Allocation failed not enough space");
                         debug!(
                             "Free space is {:?} blocks",
-                            self.handler.get_free_space_tier(class)
+                            self.handler.free_space_tier(class)
                         );
                         continue 'class;
                     }
@@ -566,7 +566,7 @@ where
             info!("Allocated {:?} at {:?}", size, disk_offset);
             debug!(
                 "Remaining space is {:?} blocks",
-                self.handler.get_free_space_tier(class)
+                self.handler.free_space_tier(class)
             );
             self.handler
                 .update_allocation_bitmap(disk_offset, size, Action::Allocate, self)?;

--- a/betree/src/data_management/dmu.rs
+++ b/betree/src/data_management/dmu.rs
@@ -518,7 +518,7 @@ where
                         class,
                         disk_id,
                         self.handler
-                            .get_free_space(class, disk_id)
+                            .get_free_space(DiskOffset::construct_disk_id(class, disk_id))
                             .expect("We can be sure that this disk id exists.")
                             .free,
                     )

--- a/betree/src/data_management/impls.rs
+++ b/betree/src/data_management/impls.rs
@@ -156,7 +156,6 @@ where
     where
         E: Deserializer<'de>,
     {
-        debug!("Deserializing");
         ObjectPointer::<D>::deserialize(deserializer).map(ObjRef::Incomplete)
     }
 }

--- a/betree/src/data_management/mod.rs
+++ b/betree/src/data_management/mod.rs
@@ -17,8 +17,9 @@ use crate::{
     database::DatasetId,
     migration::DmlMsg,
     size::{Size, StaticSize},
-    storage_pool::{DiskOffset, StoragePoolLayer},
+    storage_pool::{DiskOffset, GlobalDiskId, StoragePoolLayer},
     tree::PivotKey,
+    vdev::Block,
     StoragePreference,
 };
 use parking_lot::Mutex;

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -508,7 +508,7 @@ impl DatasetInner<DefaultMessageAction> {
     }
 
     pub(crate) fn free_space_tier(&self, pref: StoragePreference) -> Result<StorageInfo> {
-        if let Some(info) = self.tree.dmu().handler().get_free_space_tier(pref.as_u8()) {
+        if let Some(info) = self.tree.dmu().handler().free_space_tier(pref.as_u8()) {
             Ok(info)
         } else {
             Err(Error::DoesNotExist)

--- a/betree/src/database/dataset.rs
+++ b/betree/src/database/dataset.rs
@@ -1,4 +1,4 @@
-use super::root_tree_msg;
+use super::root_tree_msg::dataset;
 use super::{
     errors::*, fetch_ds_data, Database, DatasetData, DatasetId, DatasetTree, Generation,
     MessageTree, StorageInfo, RootDmu,
@@ -50,7 +50,7 @@ impl<Message> From<DatasetInner<Message>> for Dataset<Message> {
 
 impl Database {
     fn lookup_dataset_id(&self, name: &[u8]) -> Result<DatasetId> {
-        let key = root_tree_msg::ds_name_to_id(name);
+        let key = dataset::name_to_id(name);
         let data = self.root_tree.get(key)?.ok_or(Error::DoesNotExist)?;
         Ok(DatasetId::unpack(&data))
     }
@@ -160,7 +160,7 @@ impl Database {
         );
         let ptr = tree.sync()?;
 
-        let key = &root_tree_msg::ds_data_key(ds_id) as &[_];
+        let key = &dataset::data_key(ds_id) as &[_];
         let data = DatasetData {
             ptr,
             previous_snapshot: None,
@@ -197,7 +197,7 @@ impl Database {
     }
 
     fn allocate_ds_id(&mut self) -> Result<DatasetId> {
-        let key = &root_tree_msg::ds_id_counter() as &[_];
+        let key = &dataset::id_counter() as &[_];
         let last_ds_id = self
             .root_tree
             .get(key)?
@@ -215,8 +215,8 @@ impl Database {
 
     /// Iterates over all data sets in the database.
     pub fn iter_datasets(&self) -> Result<impl Iterator<Item = Result<SlicedCowBytes>>> {
-        let low = &root_tree_msg::ds_data_key(DatasetId::default()) as &[_];
-        let high = &[root_tree_msg::DATASET_DATA + 1] as &[_];
+        let low = &dataset::data_key(DatasetId::default()) as &[_];
+        let high = &dataset::data_key_max() as &[_];
         Ok(self.root_tree.range(low..high)?.map(move |result| {
             let (b, _) = result?;
             let len = b.len() as u32;

--- a/betree/src/database/handler.rs
+++ b/betree/src/database/handler.rs
@@ -1,6 +1,6 @@
 use super::{
-    errors::*, root_tree_msg, AtomicStorageInfo, DatasetId, DeadListData, Generation, Object,
-    ObjectPointer, ObjectRef, StorageInfo, TreeInner,
+    errors::*, root_tree_msg::deadlist, AtomicStorageInfo, DatasetId, DeadListData, Generation,
+    Object, ObjectPointer, ObjectRef, StorageInfo, TreeInner,
 };
 use crate::{
     allocator::{Action, SegmentAllocator, SegmentId, SEGMENT_SIZE_BYTES},
@@ -229,9 +229,7 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             CopyOnWriteEvent::Removed
         } else {
             // Add to dead list
-            let key =
-                &root_tree_msg::dead_list_key(dataset_id, self.current_generation.read(), offset)
-                    as &[_];
+            let key = &deadlist::key(dataset_id, self.current_generation.read(), offset) as &[_];
 
             let data = DeadListData {
                 birth: generation,

--- a/betree/src/database/handler.rs
+++ b/betree/src/database/handler.rs
@@ -1,6 +1,6 @@
 use super::{
-    dead_list_key, errors::*, AtomicStorageInfo, DatasetId, DeadListData, Generation, StorageInfo,
-    TreeInner,
+    errors::*, root_tree_msg, AtomicStorageInfo, DatasetId, DeadListData, Generation, Object,
+    ObjectPointer, ObjectRef, StorageInfo, TreeInner,
 };
 use crate::{
     allocator::{Action, SegmentAllocator, SegmentId, SEGMENT_SIZE_BYTES},
@@ -229,7 +229,9 @@ impl<OR: ObjectReference + HasStoragePreference> Handler<OR> {
             CopyOnWriteEvent::Removed
         } else {
             // Add to dead list
-            let key = &dead_list_key(dataset_id, self.current_generation.read(), offset) as &[_];
+            let key =
+                &root_tree_msg::dead_list_key(dataset_id, self.current_generation.read(), offset)
+                    as &[_];
 
             let data = DeadListData {
                 birth: generation,

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -297,7 +297,7 @@ impl DatabaseConfiguration {
                     .dmu()
                     .handler()
                     .free_space
-                    .get(&BigEndian::read_u16(&disk_id[1..]))
+                    .get(&space_accounting::read_key(&disk_id))
                     .unwrap();
                 let stored_info: StorageInfo = bincode::deserialize(&space)?;
                 space_info
@@ -582,7 +582,7 @@ impl Database {
                 .root_tree
                 .dmu()
                 .handler()
-                .get_free_space_tier(idx as u8)
+                .free_space_tier(idx as u8)
                 .expect("Class hat to exist");
         }
         Superblock::<ObjectPointer>::write_superblock(pool, &root_ptr, &info)?;
@@ -613,7 +613,7 @@ impl Database {
                 self.root_tree
                     .dmu()
                     .handler()
-                    .get_free_space_tier(class)
+                    .free_space_tier(class)
                     .unwrap()
             })
             .collect()

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -297,7 +297,7 @@ impl DatabaseConfiguration {
                     .dmu()
                     .handler()
                     .free_space
-                    .get(&BigEndian::read_u16(&disk_id))
+                    .get(&BigEndian::read_u16(&disk_id[1..]))
                     .unwrap();
                 let stored_info: StorageInfo = bincode::deserialize(&space)?;
                 space_info

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -42,7 +42,7 @@ use std::{
 mod dataset;
 pub(crate) mod errors;
 mod handler;
-mod root_tree_msg;
+pub(crate) mod root_tree_msg;
 mod snapshot;
 mod storage_info;
 mod superblock;

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -48,7 +48,7 @@ mod storage_info;
 mod superblock;
 mod sync_timer;
 
-use root_tree_msg::snapshot as snapshot_key;
+use root_tree_msg::{dataset as dataset_key, snapshot as snapshot_key};
 use storage_info::AtomicStorageInfo;
 pub use storage_info::StorageInfo;
 
@@ -492,7 +492,7 @@ impl Database {
         let ptr = ds_tree.erased_sync()?;
         trace!("sync_ds: erased_sync");
         let msg = DatasetData::update_ptr(ptr)?;
-        let key = &root_tree_msg::ds_data_key(ds_id) as &[_];
+        let key = &dataset_key::data_key(ds_id) as &[_];
         self.root_tree.insert(key, msg, StoragePreference::NONE)?;
         Ok(())
     }
@@ -606,7 +606,7 @@ fn fetch_ds_data<T>(root_tree: &T, id: DatasetId) -> Result<DatasetData<ObjectPo
 where
     T: TreeLayer<DefaultMessageAction>,
 {
-    let key = &root_tree_msg::ds_data_key(id) as &[_];
+    let key = &dataset_key::data_key(id) as &[_];
     let data = root_tree.get(key)?.ok_or(Error::DoesNotExist)?;
     DatasetData::unpack(&data)
 }

--- a/betree/src/database/mod.rs
+++ b/betree/src/database/mod.rs
@@ -48,6 +48,7 @@ mod storage_info;
 mod superblock;
 mod sync_timer;
 
+use root_tree_msg::snapshot as snapshot_key;
 use storage_info::AtomicStorageInfo;
 pub use storage_info::StorageInfo;
 
@@ -618,7 +619,7 @@ fn fetch_ss_data<T>(
 where
     T: TreeLayer<DefaultMessageAction>,
 {
-    let key = root_tree_msg::ss_data_key(ds_id, ss_id);
+    let key = snapshot_key::data_key(ds_id, ss_id);
     let data = root_tree.get(key)?.ok_or(Error::DoesNotExist)?;
     DatasetData::unpack(&data)
 }

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -15,7 +15,7 @@ pub(super) const DATASET_DATA: u8 = 2;
 pub(super) const SNAPSHOT_DS_ID_AND_NAME_TO_ID: u8 = 3;
 pub(super) const SNAPSHOT_DATA: u8 = 4;
 pub(super) const DEADLIST: u8 = 5;
-pub(super) const DISK_SPACE: u8 = 6;
+pub(super) const DISK_SPACE: u8 = 9;
 
 // DATASETS
 

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -4,7 +4,12 @@
 //! To add new messages define an additional prefix and describe the purpose of
 //! it here.
 
+// NOTE: Dataset counter and segment is doubly occupied, as only a single
+// counter may ever exist and all segment entries have keys of length 9 this is
+// fine.
 pub(super) const DATASET_ID_COUNTER: u8 = 0;
+pub(super) const SEGMENT: u8 = 0;
+
 pub(super) const DATASET_NAME_TO_ID: u8 = 1;
 pub(super) const DATASET_DATA: u8 = 2;
 pub(super) const SNAPSHOT_DS_ID_AND_NAME_TO_ID: u8 = 3;
@@ -47,6 +52,26 @@ pub(super) mod dataset {
     // Above-Upper End of dataset data keys for the use in non-inclusive range queries.
     pub fn data_key_max() -> [u8; 1] {
         [DATASET_DATA + 1]
+    }
+}
+
+// SEGMENTS
+
+pub(super) mod segment {
+    use byteorder::{BigEndian, ByteOrder};
+
+    use crate::allocator::SegmentId;
+
+    use super::SEGMENT;
+
+    const S_ID_OFFSET: usize = 1;
+    const FULL: usize = 9;
+
+    pub fn id_to_key(segment_id: SegmentId) -> [u8; FULL] {
+        let mut key = [0; FULL];
+        key[0] = SEGMENT;
+        BigEndian::write_u64(&mut key[S_ID_OFFSET..], segment_id.0);
+        key
     }
 }
 

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -15,6 +15,9 @@ pub(super) const DATASET_DATA: u8 = 2;
 pub(super) const SNAPSHOT_DS_ID_AND_NAME_TO_ID: u8 = 3;
 pub(super) const SNAPSHOT_DATA: u8 = 4;
 pub(super) const DEADLIST: u8 = 5;
+pub(crate) const OBJECT_STORE_ID_COUNTER_PREFIX: u8 = 6;
+pub(crate) const OBJECT_STORE_NAME_TO_ID_PREFIX: u8 = 7;
+pub(crate) const OBJECT_STORE_DATA_PREFIX: u8 = 8;
 pub(super) const DISK_SPACE: u8 = 9;
 
 // DATASETS

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -15,6 +15,7 @@ pub(super) const DATASET_DATA: u8 = 2;
 pub(super) const SNAPSHOT_DS_ID_AND_NAME_TO_ID: u8 = 3;
 pub(super) const SNAPSHOT_DATA: u8 = 4;
 pub(super) const DEADLIST: u8 = 5;
+pub(super) const DISK_SPACE: u8 = 6;
 
 // DATASETS
 
@@ -170,5 +171,35 @@ pub(super) mod deadlist {
 
     pub fn offset_from_key(key: &[u8]) -> DiskOffset {
         DiskOffset::from_u64(BigEndian::read_u64(&key[DO_OFFSET..]))
+    }
+}
+
+// SPACE ACCOUNTING
+
+pub(super) mod space_accounting {
+    //! Each space accounting entry is characterized by the 1 bit prefix
+    //! followed by a 16 bit disk id.  The tier summarization is for simplicity
+    //! encoded in the superblock instead.
+
+    use byteorder::{BigEndian, ByteOrder};
+
+    use super::DISK_SPACE;
+
+    const FULL: usize = 3;
+    const D_ID_OFFSET: usize = 1;
+
+    pub fn key(disk_id: u16) -> [u8; FULL] {
+        let mut key = [0u8; FULL];
+        key[0] = DISK_SPACE;
+        BigEndian::write_u16(&mut key[D_ID_OFFSET..], disk_id);
+        key
+    }
+
+    pub fn min_key() -> [u8; 1] {
+        [DISK_SPACE]
+    }
+
+    pub fn max_key() -> [u8; 1] {
+        [DISK_SPACE + 1]
     }
 }

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -1,0 +1,96 @@
+//! This file contains creation definition for messages in the root tree of a
+//! database. Several prefix are used, which are defined here as constants.
+//!
+//! To add new messages define an additional prefix and describe the purpose of
+//! it here.
+
+use crate::storage_pool::DiskOffset;
+use byteorder::{BigEndian, ByteOrder};
+
+use super::{DatasetId, Generation};
+
+pub(super) const DATASET_ID_COUNTER: u8 = 0;
+pub(super) const DATASET_NAME_TO_ID: u8 = 1;
+pub(super) const DATASET_DATA: u8 = 2;
+pub(super) const SNAPSHOT_DS_ID_AND_NAME_TO_ID: u8 = 3;
+pub(super) const SNAPSHOT_DATA: u8 = 4;
+pub(super) const DEADLIST: u8 = 5;
+
+pub(super) fn ds_id_counter() -> [u8; 1] {
+    [DATASET_ID_COUNTER]
+}
+
+pub(super) fn ds_name_to_id(name: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(1 + name.len());
+    key.push(DATASET_NAME_TO_ID);
+    key.extend_from_slice(name);
+    key
+}
+
+pub(super) fn ds_data_key(id: DatasetId) -> [u8; 9] {
+    let mut key = [0; 9];
+    key[0] = DATASET_DATA;
+    key[1..].copy_from_slice(&id.pack());
+    key
+}
+
+// SNAPSHOTS
+
+pub(super) fn ss_key(ds_id: DatasetId, name: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(1 + 8 + name.len());
+    key.push(SNAPSHOT_DS_ID_AND_NAME_TO_ID);
+    key.extend_from_slice(&ds_id.pack());
+    key.extend_from_slice(name);
+    key
+}
+
+pub(super) fn ss_data_key(ds_id: DatasetId, ss_id: Generation) -> [u8; 17] {
+    let mut key = [0; 17];
+    key[0] = SNAPSHOT_DATA;
+    key[1..9].copy_from_slice(&ds_id.pack());
+    key[9..].copy_from_slice(&ss_id.pack());
+    key
+}
+
+pub(super) fn ss_data_key_max(mut ds_id: DatasetId) -> [u8; 9] {
+    ds_id.0 += 1;
+    let mut key = [0; 9];
+    key[0] = SNAPSHOT_DATA;
+    key[1..9].copy_from_slice(&ds_id.pack());
+    key
+}
+
+// DEADLIST - snapshot only objects
+
+pub(super) fn dead_list_min_key(ds_id: DatasetId, ss_id: Generation) -> [u8; 17] {
+    let mut key = [0; 17];
+    key[0] = 5;
+    key[1..9].copy_from_slice(&ds_id.pack());
+    key[9..].copy_from_slice(&ss_id.pack());
+    key
+}
+
+pub(super) fn dead_list_max_key(ds_id: DatasetId, ss_id: Generation) -> [u8; 17] {
+    dead_list_min_key(ds_id, ss_id.next())
+}
+
+pub(super) fn dead_list_max_key_ds(mut ds_id: DatasetId) -> [u8; 9] {
+    ds_id.0 += 1;
+    let mut key = [0; 9];
+    key[0] = 5;
+    key[1..9].copy_from_slice(&ds_id.pack());
+    key
+}
+
+pub(super) fn dead_list_key(ds_id: DatasetId, cur_gen: Generation, offset: DiskOffset) -> [u8; 25] {
+    let mut key = [0; 25];
+    key[0] = DEADLIST;
+    key[1..9].copy_from_slice(&ds_id.pack());
+    key[9..17].copy_from_slice(&cur_gen.pack());
+    BigEndian::write_u64(&mut key[17..], offset.as_u64());
+    key
+}
+
+pub(super) fn offset_from_dead_list_key(key: &[u8]) -> DiskOffset {
+    DiskOffset::from_u64(BigEndian::read_u64(&key[17..]))
+}

--- a/betree/src/database/root_tree_msg.rs
+++ b/betree/src/database/root_tree_msg.rs
@@ -186,16 +186,25 @@ pub(super) mod space_accounting {
 
     use byteorder::{BigEndian, ByteOrder};
 
+    use crate::storage_pool::GlobalDiskId;
+
     use super::DISK_SPACE;
 
     const FULL: usize = 3;
     const D_ID_OFFSET: usize = 1;
 
-    pub fn key(disk_id: u16) -> [u8; FULL] {
+    pub fn key(disk_id: GlobalDiskId) -> [u8; FULL] {
         let mut key = [0u8; FULL];
         key[0] = DISK_SPACE;
-        BigEndian::write_u16(&mut key[D_ID_OFFSET..], disk_id);
+        BigEndian::write_u16(&mut key[D_ID_OFFSET..], disk_id.as_u16());
         key
+    }
+
+    /// This function should always receive a buffer of exactly FULL length.
+    /// Other usages are not intended nor supported.
+    pub fn read_key(buf: &[u8]) -> GlobalDiskId {
+        debug_assert!(buf.len() == FULL);
+        GlobalDiskId(BigEndian::read_u16(&buf[D_ID_OFFSET..]))
     }
 
     pub fn min_key() -> [u8; 1] {

--- a/betree/src/database/snapshot.rs
+++ b/betree/src/database/snapshot.rs
@@ -1,5 +1,5 @@
 use super::{
-    dataset::Dataset, errors::*, fetch_ds_data, fetch_ss_data, root_tree_msg,
+    dataset::Dataset, errors::*, fetch_ds_data, fetch_ss_data, root_tree_msg::dataset,
     root_tree_msg::deadlist, root_tree_msg::snapshot, Database, DatasetData, DatasetId,
     DatasetTree, DeadListData, Generation, ObjectPointer, RootDmu
 };
@@ -67,7 +67,7 @@ impl Database {
             DefaultMessageAction::insert_msg(&data),
             StoragePreference::NONE,
         )?;
-        let key = &root_tree_msg::ds_data_key(ds.id()) as &[_];
+        let key = &dataset::data_key(ds.id()) as &[_];
         self.root_tree.insert(
             key,
             DatasetData::<ObjectPointer>::update_previous_snapshot(Some(ss_id)),
@@ -125,7 +125,7 @@ impl Database {
             &max_key_snapshot as &[_]
         } else {
             self.root_tree.insert(
-                &root_tree_msg::ds_data_key(ds.id()) as &[_],
+                &dataset::data_key(ds.id()) as &[_],
                 update_previous_ss_msg,
                 StoragePreference::NONE,
             )?;

--- a/betree/src/database/storage_info.rs
+++ b/betree/src/database/storage_info.rs
@@ -42,7 +42,7 @@ impl StorageInfo {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 /// Atomic version of [StorageInfo].
 pub(crate) struct AtomicStorageInfo {
     pub(crate) free: AtomicU64,

--- a/betree/src/metrics/mod.rs
+++ b/betree/src/metrics/mod.rs
@@ -69,7 +69,7 @@ fn metrics_loop<Config>(cfg: MetricsConfiguration, output: fs::File, dmu: Arc<Ro
             storage: spu.metrics(),
             // We can be sure that the following is always correct
             usage: (0..NUM_STORAGE_CLASSES as u8)
-                .map(|tier| dmu.handler().get_free_space_tier(tier).unwrap())
+                .map(|tier| dmu.handler().free_space_tier(tier).unwrap())
                 .collect(),
         };
 

--- a/betree/src/migration/mod.rs
+++ b/betree/src/migration/mod.rs
@@ -243,7 +243,7 @@ pub(crate) trait MigrationPolicy {
                 .filter_map(|class| {
                     self.dmu()
                         .handler()
-                        .get_free_space_tier(class)
+                        .free_space_tier(class)
                         .map(|blocks| (class, blocks))
                 })
                 .collect();
@@ -264,7 +264,7 @@ pub(crate) trait MigrationPolicy {
                 .filter_map(|class| {
                     self.dmu()
                         .handler()
-                        .get_free_space_tier(class)
+                        .free_space_tier(class)
                         .map(|blocks| (class, blocks))
                 })
                 .collect();

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -229,7 +229,7 @@ impl Database {
     pub fn internal_open_object_store_with_id(
         &mut self,
         os_id: ObjectStoreId,
-    ) -> Result<ObjectStore<Config>> {
+    ) -> Result<ObjectStore> {
         self.open_object_store_with_id(os_id)
     }
 

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -225,6 +225,15 @@ impl Database {
             .map(|buf| ObjectStoreData::unpack(&buf)))
     }
 
+    /// For tests only: Exposed version of [object_object_store_with_id].
+    #[cfg(feature = "internal-api")]
+    pub fn internal_open_object_store_with_id(
+        &mut self,
+        os_id: ObjectStoreId,
+    ) -> Result<ObjectStore<Config>> {
+        self.open_object_store_with_id(os_id)
+    }
+
     /// Open an object store by its internal Id. This method can be used
     /// whenever storing the actual names of object stores is too much expected
     /// effort.

--- a/betree/src/object/mod.rs
+++ b/betree/src/object/mod.rs
@@ -48,6 +48,9 @@
 use crate::{
     cow_bytes::{CowBytes, SlicedCowBytes},
     data_management::Dml,
+    database::root_tree_msg::{
+        OBJECT_STORE_DATA_PREFIX, OBJECT_STORE_ID_COUNTER_PREFIX, OBJECT_STORE_NAME_TO_ID_PREFIX,
+    },
     database::{DatasetId, Error, Result},
     migration::{DatabaseMsg, GlobalObjectId},
     size::StaticSize,
@@ -158,10 +161,6 @@ impl ObjectStoreData {
         }
     }
 }
-
-const OBJECT_STORE_ID_COUNTER_PREFIX: u8 = 6;
-const OBJECT_STORE_NAME_TO_ID_PREFIX: u8 = 7;
-const OBJECT_STORE_DATA_PREFIX: u8 = 8;
 
 impl Database {
     fn allocate_os_id(&mut self) -> Result<ObjectStoreId> {

--- a/betree/src/storage_pool/disk_offset.rs
+++ b/betree/src/storage_pool/disk_offset.rs
@@ -11,6 +11,8 @@ const MASK_STORAGE_CLASS: u64 = ((1 << 2) - 1) << (10 + 52);
 const MASK_DISK_ID: u64 = ((1 << 10) - 1) << 52;
 const MASK_OFFSET: u64 = (1 << 52) - 1;
 
+const MASK_CLASS_DISK_ID_COMBINED: u64 = ((1 << 12) - 1) << 52;
+
 impl DiskOffset {
     /// Constructs a new `DiskOffset`.
     /// The given `block_offset` may not be larger than (1 << 52) - 1.
@@ -30,6 +32,10 @@ impl DiskOffset {
     /// Returns the 10-bit disk ID.
     pub fn disk_id(&self) -> u16 {
         ((self.0 & MASK_DISK_ID) >> 52) as u16
+    }
+    /// Returns the 12-bit storage class with attached disk ID.
+    pub fn class_disk_id(&self) -> u16 {
+        ((self.0 & MASK_CLASS_DISK_ID_COMBINED) >> 52) as u16
     }
     /// Returns the block offset.
     pub fn block_offset(&self) -> Block<u64> {

--- a/betree/src/storage_pool/disk_offset.rs
+++ b/betree/src/storage_pool/disk_offset.rs
@@ -10,7 +10,6 @@ pub struct DiskOffset(u64);
 const MASK_STORAGE_CLASS: u64 = ((1 << 2) - 1) << (10 + 52);
 const MASK_DISK_ID: u64 = ((1 << 10) - 1) << 52;
 const MASK_OFFSET: u64 = (1 << 52) - 1;
-
 const MASK_CLASS_DISK_ID_COMBINED: u64 = ((1 << 12) - 1) << 52;
 
 impl DiskOffset {
@@ -48,6 +47,12 @@ impl DiskOffset {
     /// Constructs a disk offset from the given `u64`.
     pub fn from_u64(x: u64) -> Self {
         DiskOffset(x)
+    }
+
+    // Glue together a class identifier with a class depdendent disk_id.
+    // TODO: Provide typization for this?
+    pub fn construct_disk_id(class: u8, disk_id: u16) -> u16 {
+        ((class as u16) << 10) | disk_id
     }
 }
 

--- a/betree/src/storage_pool/disk_offset.rs
+++ b/betree/src/storage_pool/disk_offset.rs
@@ -12,6 +12,22 @@ const MASK_DISK_ID: u64 = ((1 << 10) - 1) << 52;
 const MASK_OFFSET: u64 = (1 << 52) - 1;
 const MASK_CLASS_DISK_ID_COMBINED: u64 = ((1 << 12) - 1) << 52;
 
+/// An identifier containing the class id and disk id. Uniquely identifies a
+/// disk over all storage devices.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlobalDiskId(pub u16);
+
+impl GlobalDiskId {
+    /// Expose the internal representation of the identifier.
+    pub fn as_u16(&self) -> u16 {
+        self.0
+    }
+}
+
+/// A class specific disk identifier. Only unique within a set class and only
+/// valid for the original class.
+pub struct LocalDiskId(u16);
+
 impl DiskOffset {
     /// Constructs a new `DiskOffset`.
     /// The given `block_offset` may not be larger than (1 << 52) - 1.
@@ -33,8 +49,8 @@ impl DiskOffset {
         ((self.0 & MASK_DISK_ID) >> 52) as u16
     }
     /// Returns the 12-bit storage class with attached disk ID.
-    pub fn class_disk_id(&self) -> u16 {
-        ((self.0 & MASK_CLASS_DISK_ID_COMBINED) >> 52) as u16
+    pub fn class_disk_id(&self) -> GlobalDiskId {
+        GlobalDiskId(((self.0 & MASK_CLASS_DISK_ID_COMBINED) >> 52) as u16)
     }
     /// Returns the block offset.
     pub fn block_offset(&self) -> Block<u64> {
@@ -50,9 +66,8 @@ impl DiskOffset {
     }
 
     // Glue together a class identifier with a class depdendent disk_id.
-    // TODO: Provide typization for this?
-    pub fn construct_disk_id(class: u8, disk_id: u16) -> u16 {
-        ((class as u16) << 10) | disk_id
+    pub fn construct_disk_id(class: u8, disk_id: u16) -> GlobalDiskId {
+        GlobalDiskId(((class as u16) << 10) | disk_id)
     }
 }
 

--- a/betree/src/storage_pool/mod.rs
+++ b/betree/src/storage_pool/mod.rs
@@ -99,7 +99,7 @@ pub trait StoragePoolLayer: Clone + Send + Sync + 'static {
 }
 
 mod disk_offset;
-pub use self::disk_offset::DiskOffset;
+pub use self::disk_offset::{DiskOffset, GlobalDiskId, LocalDiskId};
 
 pub mod configuration;
 pub use self::configuration::{

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -131,7 +131,7 @@ fn object_store_reinit_from_id() {
     let mut db = test_db(2, 64);
     let os = db.open_object_store().unwrap();
     db.close_object_store(os);
-    let mut osl = db.iter_object_stores().unwrap();
+    let mut osl = db.iter_object_stores_pub().unwrap();
     let _ = db
         .internal_open_object_store_with_id(osl.next().unwrap().unwrap())
         .unwrap();

--- a/betree/tests/src/object_store.rs
+++ b/betree/tests/src/object_store.rs
@@ -125,3 +125,14 @@ fn object_store_access_pattern() {
     db.sync().unwrap();
     assert!(db.free_space_tier()[0].free < db.free_space_tier()[1].free);
 }
+
+#[test]
+fn object_store_reinit_from_id() {
+    let mut db = test_db(2, 64);
+    let os = db.open_object_store().unwrap();
+    db.close_object_store(os);
+    let mut osl = db.iter_object_stores().unwrap();
+    let _ = db
+        .internal_open_object_store_with_id(osl.next().unwrap().unwrap())
+        .unwrap();
+}


### PR DESCRIPTION
This PR implements two essential features, first it finalized space accounting previously introduced with #2 as it now also stores the disk space information in the root tree based on their 12bit global identifier. Second, this information is then used to start the Segment map search to find satisfying slots for the next allocation. This brings us a better scalability when not using Parity setups, second it allows for a more holistic overview of the current storage state, also helpful for user inspection.

In the process of this, we clean up the root tree keys by centralizing them in a separate module. Documentation for this is provided as module level documentation, easing the introduction of future keys.