### PR TITLE
Bump betree v0.3.0

### DIFF
--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "betree_storage_stack"
-version = "0.3.0"
+version = "0.3.1-alpha"
 authors = ["Felix Wiedemann <felix@kann.it>", "Till Hoeppner <betree@tilpner.com>", "Johannes Wünsche <johannes@spacesnek.rocks>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/betree/Cargo.toml
+++ b/betree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "betree_storage_stack"
-version = "0.2.1-alpha"
+version = "0.3.0"
 authors = ["Felix Wiedemann <felix@kann.it>", "Till Hoeppner <betree@tilpner.com>", "Johannes Wünsche <johannes@spacesnek.rocks>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Maintenance PR. Allows for safe navigation back to the last commit before any rebuild occurs.